### PR TITLE
Handle Enter key for search inputs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -31,9 +31,17 @@ function wireEvents() {
     state.fleetFilter.location = event.target.value;
     renderFleet();
   });
-  $('#searchBtn').addEventListener('click', () => {
+  const applyFleetSearch = () => {
     state.fleetFilter.query = $('#searchInput').value;
     renderFleet();
+  };
+
+  $('#searchBtn').addEventListener('click', applyFleetSearch);
+  $('#searchInput').addEventListener('keydown', event => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      applyFleetSearch();
+    }
   });
 
   document.addEventListener('click', event => {
@@ -197,7 +205,17 @@ function wireEvents() {
   });
 
   $('#activityLocationFilter').addEventListener('change', renderActivity);
-  $('#activitySearchBtn').addEventListener('click', renderActivity);
+  const applyActivitySearch = () => {
+    renderActivity();
+  };
+
+  $('#activitySearchBtn').addEventListener('click', applyActivitySearch);
+  $('#activitySearchInput').addEventListener('keydown', event => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      applyActivitySearch();
+    }
+  });
 
   $('#btnAddUser').addEventListener('click', () => {
     state.editUserId = null;


### PR DESCRIPTION
## Summary
- trigger the fleet filter when the Enter key is pressed in the search field
- trigger the activity search when the Enter key is pressed in its input
- centralize the search handlers so button clicks and key presses share the same logic

## Testing
- python -m http.server 8000 (manual)
- Playwright search Enter check

------
https://chatgpt.com/codex/tasks/task_e_68e69ad7235c832bba331077dd0c3677