### PR TITLE
Add Supabase integration for live data

### DIFF
--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -1,0 +1,122 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.48.0';
+
+const SUPABASE_URL = 'https://ezcxfobjsvomcjuwbgep.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV6Y3hmb2Jqc3ZvbWNqdXdiZ2VwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc2NzQ3ODcsImV4cCI6MjA3MzI1MDc4N30.IhYZYfB_N2JDOG82NFbB_wxY7BJhahqJd9Y71nhpI3I';
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: {
+    persistSession: false
+  }
+});
+
+export async function fetchLocations() {
+  const { data, error } = await supabase
+    .from('locations_with_all')
+    .select('name')
+    .order('name');
+
+  if (error) throw error;
+
+  const names = (data || []).map(location => location.name);
+  const unique = Array.from(new Set(names.filter(Boolean)));
+  if (!unique.includes('Alle locaties')) {
+    unique.unshift('Alle locaties');
+  }
+
+  return unique;
+}
+
+function mapContract(rawContract) {
+  const contract = Array.isArray(rawContract) ? rawContract[0] : rawContract;
+  if (!contract) {
+    return {
+      nummer: '—',
+      start: null,
+      eind: null,
+      uren: null,
+      type: '—',
+      model: '—'
+    };
+  }
+
+  return {
+    nummer: contract.contract_number ?? '—',
+    start: contract.start_date ?? null,
+    eind: contract.end_date ?? null,
+    uren: contract.hours_per_year ?? null,
+    type: contract.contract_type ?? '—',
+    model: contract.model ?? '—'
+  };
+}
+
+function mapActivity(rawActivity = []) {
+  return rawActivity
+    .map(item => ({
+      id: item.activity_code ?? '—',
+      type: item.activity_type ?? 'Onbekend',
+      desc: item.description ?? '',
+      status: item.status ?? 'Open',
+      date: item.activity_date ?? null
+    }))
+    .sort((a, b) => new Date(b.date || 0) - new Date(a.date || 0));
+}
+
+export async function fetchFleet() {
+  const { data, error } = await supabase
+    .from('fleet_assets')
+    .select(`
+      id,
+      reference,
+      model,
+      bmw_status,
+      bmw_expiry,
+      odo,
+      odo_date,
+      active,
+      location:location_id ( name ),
+      contract:fleet_contracts ( contract_number, start_date, end_date, hours_per_year, contract_type, model ),
+      activity:fleet_activity ( activity_code, activity_type, description, status, activity_date )
+    `)
+    .order('id');
+
+  if (error) throw error;
+
+  return (data || []).map(item => ({
+    id: item.id,
+    ref: item.reference ?? '—',
+    model: item.model ?? '—',
+    bmwStatus: item.bmw_status ?? 'Onbekend',
+    bmwExpiry: item.bmw_expiry ?? null,
+    odo: typeof item.odo === 'number' ? item.odo : Number(item.odo ?? 0),
+    odoDate: item.odo_date ?? null,
+    location: item.location?.name ?? 'Onbekende locatie',
+    activity: mapActivity(item.activity),
+    contract: mapContract(item.contract),
+    active: item.active ?? true
+  }));
+}
+
+export async function fetchUsers() {
+  const { data, error } = await supabase
+    .from('portal_users')
+    .select(`
+      id,
+      display_name,
+      email,
+      phone,
+      role,
+      location:location_id ( name )
+    `)
+    .order('display_name');
+
+  if (error) throw error;
+
+  return (data || []).map(user => ({
+    id: user.id,
+    name: user.display_name ?? '—',
+    email: user.email ?? '',
+    phone: user.phone ?? '',
+    location: user.location?.name ?? '—',
+    role: user.role ?? 'Gebruiker'
+  }));
+}

--- a/src/data.js
+++ b/src/data.js
@@ -1,11 +1,11 @@
-export const LOCATIONS = [
+const DEFAULT_LOCATIONS = [
   'Alle locaties',
   'Demovloot Motrac – Almere',
   'Demovloot Motrac – Venlo',
   'Demovloot Motrac – Zwijndrecht'
 ];
 
-export const FLEET = [
+const DEFAULT_FLEET = [
   {
     id: 'E16-123456',
     ref: 'Reachtruck – Magazijn A',
@@ -73,7 +73,7 @@ export const FLEET = [
   }
 ];
 
-export const USERS = [
+const DEFAULT_USERS = [
   { id: 'U1', name: 'Test User 2', email: 'test2@example.com', phone: '+31 6 12345678', location: 'Demovloot Motrac – Almere', role: 'Beheerder' },
   { id: 'U2', name: 'Jan Jansen', email: 'jan.jansen@example.com', phone: '+31 6 98765432', location: 'Demovloot Motrac – Venlo', role: 'Gebruiker' },
   { id: 'U3', name: 'Eva Visser', email: 'eva.visser@example.com', phone: '+31 6 45678901', location: 'Demovloot Motrac – Zwijndrecht', role: 'Gebruiker' },
@@ -86,3 +86,40 @@ export const USERS = [
   { id: 'U10', name: 'William de Vries', email: 'w.vries@example.com', phone: '+31 6 66667777', location: 'Demovloot Motrac – Zwijndrecht', role: 'Gebruiker' },
   { id: 'U11', name: 'Noa Willems', email: 'n.willems@example.com', phone: '+31 6 77778888', location: 'Demovloot Motrac – Almere', role: 'Gebruiker' }
 ];
+
+export let LOCATIONS = [...DEFAULT_LOCATIONS];
+export let FLEET = DEFAULT_FLEET.map(item => ({
+  ...item,
+  activity: item.activity.map(activity => ({ ...activity }))
+}));
+export let USERS = [...DEFAULT_USERS];
+
+export function setLocations(locations = []) {
+  const cleaned = Array.isArray(locations) ? locations.filter(Boolean) : [];
+  const unique = Array.from(new Set(cleaned));
+  if (!unique.includes('Alle locaties')) {
+    unique.unshift('Alle locaties');
+  }
+  LOCATIONS = unique;
+}
+
+export function setFleet(fleet = []) {
+  if (Array.isArray(fleet)) {
+    FLEET = fleet;
+  }
+}
+
+export function setUsers(users = []) {
+  if (Array.isArray(users)) {
+    USERS = users;
+  }
+}
+
+export function resetToDefaults() {
+  LOCATIONS = [...DEFAULT_LOCATIONS];
+  FLEET = DEFAULT_FLEET.map(item => ({
+    ...item,
+    activity: item.activity.map(activity => ({ ...activity }))
+  }));
+  USERS = [...DEFAULT_USERS];
+}

--- a/src/modules/fleet.js
+++ b/src/modules/fleet.js
@@ -3,12 +3,16 @@ import { state } from '../state.js';
 import { $, fmtDate } from '../utils.js';
 
 export function populateLocationFilters() {
+  if (!LOCATIONS.includes(state.fleetFilter.location)) {
+    state.fleetFilter.location = LOCATIONS[0] || 'Alle locaties';
+  }
   const locOptions = LOCATIONS.map(location => {
     const selected = location === state.fleetFilter.location ? 'selected' : '';
     return `<option ${selected}>${location}</option>`;
   }).join('');
   $('#locationFilter').innerHTML = locOptions;
   $('#activityLocationFilter').innerHTML = LOCATIONS.map(location => `<option>${location}</option>`).join('');
+  $('#activityLocationFilter').value = 'Alle locaties';
   $('#userLocation').innerHTML = LOCATIONS.filter(location => location !== 'Alle locaties')
     .map(location => `<option>${location}</option>`)
     .join('');

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,11 @@
 export const $ = (selector, scope = document) => scope.querySelector(selector);
 export const $$ = (selector, scope = document) => Array.from(scope.querySelectorAll(selector));
 
-export const fmtDate = iso => new Date(iso).toLocaleDateString('nl-NL');
+export const fmtDate = iso => {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  return Number.isNaN(date.valueOf()) ? '—' : date.toLocaleDateString('nl-NL');
+};
 
 export function showToast(message) {
   const toast = $('#toast');


### PR DESCRIPTION
## Summary
- add a Supabase client module configured with the provided project credentials
- load locations, fleet assets, and portal users from Supabase during app initialisation with graceful fallbacks
- adjust utilities and UI helpers to handle missing data while keeping existing sample data as fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7b225208c832bb9b63167dc2d8f4d