### PR TITLE
Handle incomplete Supabase fleet data

### DIFF
--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -39,11 +39,16 @@ function mapContract(rawContract) {
     };
   }
 
+  const hoursRaw = contract.hours_per_year;
+  const hoursNumber =
+    typeof hoursRaw === 'number' ? hoursRaw : Number(hoursRaw);
+  const uren = Number.isFinite(hoursNumber) ? hoursNumber : null;
+
   return {
     nummer: contract.contract_number ?? '—',
     start: contract.start_date ?? null,
     eind: contract.end_date ?? null,
-    uren: contract.hours_per_year ?? null,
+    uren,
     type: contract.contract_type ?? '—',
     model: contract.model ?? '—'
   };
@@ -87,7 +92,11 @@ export async function fetchFleet() {
     model: item.model ?? '—',
     bmwStatus: item.bmw_status ?? 'Onbekend',
     bmwExpiry: item.bmw_expiry ?? null,
-    odo: typeof item.odo === 'number' ? item.odo : Number(item.odo ?? 0),
+    odo: (() => {
+      const raw = item.odo;
+      const value = typeof raw === 'number' ? raw : Number(raw);
+      return Number.isFinite(value) ? value : null;
+    })(),
     odoDate: item.odo_date ?? null,
     location: item.location?.name ?? 'Onbekende locatie',
     activity: mapActivity(item.activity),

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import { FLEET, USERS, setFleet, setLocations, setUsers } from './data.js';
 import { state } from './state.js';
-import { $, $$, fmtDate, showToast, openModal, closeModals, kv } from './utils.js';
+import { $, $$, fmtDate, showToast, openModal, closeModals, kv, formatOdoLabel } from './utils.js';
 import { populateLocationFilters, renderFleet } from './modules/fleet.js';
 import { renderActivity } from './modules/activity.js';
 import { renderUsers } from './modules/users.js';
@@ -87,7 +87,7 @@ function wireEvents() {
     }
 
     if (action === 'updateOdo' || action === 'updateOdoFromDetail') {
-      $('#odoCurrent').textContent = `${truck.odo.toLocaleString('nl-NL')} (${fmtDate(truck.odoDate)})`;
+      $('#odoCurrent').textContent = formatOdoLabel(truck.odo, truck.odoDate);
       $('#odoNew').value = '';
       $('#odoSave').dataset.id = id;
       openModal('#modalOdo');
@@ -162,7 +162,8 @@ function wireEvents() {
     const id = event.target.dataset.id;
     const truck = FLEET.find(item => item.id === id);
     const value = parseInt($('#odoNew').value, 10);
-    if (Number.isNaN(value) || value < truck.odo) {
+    const currentOdo = typeof truck.odo === 'number' && Number.isFinite(truck.odo) ? truck.odo : null;
+    if (Number.isNaN(value) || value < 0 || (currentOdo !== null && value < currentOdo)) {
       showToast('Nieuwe tellerstand moet ≥ huidige zijn.');
       return;
     }

--- a/src/modules/detail.js
+++ b/src/modules/detail.js
@@ -1,6 +1,6 @@
 import { FLEET } from '../data.js';
 import { state } from '../state.js';
-import { $, $$, fmtDate, kv } from '../utils.js';
+import { $, $$, fmtDate, kv, formatOdoHtml } from '../utils.js';
 
 export function openDetail(id) {
   state.selectedTruckId = id;
@@ -30,7 +30,7 @@ export function setDetailTab(tab) {
         ${infoRow('Objectnummer', truck.id, true)}
         ${infoRow('Referentie', truck.ref, false, 'editRefFromDetail')}
         ${infoRow('Model', truck.model)}
-        ${infoRow('Tellerstand (datum)', `${truck.odo.toLocaleString('nl-NL')} (${fmtDate(truck.odoDate)})`, false, 'updateOdoFromDetail')}
+        ${infoRow('Tellerstand (datum)', formatOdoHtml(truck.odo, truck.odoDate), false, 'updateOdoFromDetail')}
         ${infoRow('BMWT‑status', truck.bmwStatus)}
         ${infoRow('BMWT‑vervaldatum', fmtDate(truck.bmwExpiry))}
       </div>`;

--- a/src/modules/fleet.js
+++ b/src/modules/fleet.js
@@ -1,6 +1,6 @@
 import { LOCATIONS, FLEET } from '../data.js';
 import { state } from '../state.js';
-import { $, fmtDate } from '../utils.js';
+import { $, fmtDate, formatOdoHtml } from '../utils.js';
 
 export function populateLocationFilters() {
   if (!LOCATIONS.includes(state.fleetFilter.location)) {
@@ -45,7 +45,7 @@ export function renderFleet() {
         <td class="py-3 px-3">${truck.model}</td>
         <td class="py-3 px-3">${truck.bmwStatus}</td>
         <td class="py-3 px-3">${fmtDate(truck.bmwExpiry)}</td>
-        <td class="py-3 px-3">${truck.odo.toLocaleString('nl-NL')} <span class="text-xs text-gray-500">(${fmtDate(truck.odoDate)})</span></td>
+        <td class="py-3 px-3">${formatOdoHtml(truck.odo, truck.odoDate)}</td>
         <td class="py-3 px-3">
           <button class="inline-flex items-center justify-center w-7 h-7 bg-red-100 text-motrac-red rounded-full font-semibold" title="Open meldingen" data-open-detail="${truck.id}">${openCount}</button>
         </td>

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,34 @@ export const fmtDate = iso => {
   return Number.isNaN(date.valueOf()) ? '—' : date.toLocaleDateString('nl-NL');
 };
 
+export const formatOdoValue = value => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value.toLocaleString('nl-NL');
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+      return numeric.toLocaleString('nl-NL');
+    }
+  }
+  return '—';
+};
+
+export const formatOdoHtml = (value, date) => {
+  const odo = formatOdoValue(value);
+  const formattedDate = fmtDate(date);
+  if (formattedDate === '—') {
+    return odo;
+  }
+  return `${odo} <span class="text-xs text-gray-500">(${formattedDate})</span>`;
+};
+
+export const formatOdoLabel = (value, date) => {
+  const odo = formatOdoValue(value);
+  const formattedDate = fmtDate(date);
+  return formattedDate === '—' ? odo : `${odo} (${formattedDate})`;
+};
+
 export function showToast(message) {
   const toast = $('#toast');
   if (!toast) return;
@@ -29,6 +57,6 @@ export function closeModals() {
 export const kv = (label, value) => `
   <div>
     <div class="text-xs text-gray-500">${label}</div>
-    <div class="font-medium">${value}</div>
+    <div class="font-medium">${value ?? '—'}</div>
   </div>
 `;


### PR DESCRIPTION
## Summary
- normalise Supabase responses so null odometer readings and contract hours no longer break the UI
- add reusable odometer formatting helpers and use them in the fleet table, detail pane and odo modal
- ensure contract metadata renders with placeholders instead of raw null values

## Testing
- node --check src/api/supabase.js
- node --check src/utils.js
- node --check src/main.js
- node --check src/modules/detail.js
- node --check src/modules/fleet.js

------
https://chatgpt.com/codex/tasks/task_e_68e7bc798c2c832bbe3e522c8ae08f06