### PR TITLE
Add Supabase user schema for Motrac Service Portaal

### DIFF
--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -107,14 +107,14 @@ export async function fetchFleet() {
 
 export async function fetchUsers() {
   const { data, error } = await supabase
-    .from('portal_users')
+    .from('motrac_service_portaal_user_directory')
     .select(`
       id,
       display_name,
       email,
       phone,
       role,
-      location:location_id ( name )
+      default_location_name
     `)
     .order('display_name');
 
@@ -125,7 +125,7 @@ export async function fetchUsers() {
     name: user.display_name ?? '—',
     email: user.email ?? '',
     phone: user.phone ?? '',
-    location: user.location?.name ?? '—',
+    location: user.default_location_name ?? '—',
     role: user.role ?? 'Gebruiker'
   }));
 }


### PR DESCRIPTION
## Summary
- add Motrac Service Portaal specific profile and location membership tables to Supabase schema
- expose a user directory view tailored for the frontend
- update the Supabase client to read users from the new view

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e7c1a7dac8832b8ba7d1067ec83cb3