### PR TITLE
Disable caching for Supabase requests and page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <title>Motrac Serviceportal – Prototype</title>
   <!-- TailwindCSS CDN for rapid prototyping -->
   <script src="https://cdn.tailwindcss.com"></script>

--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -3,9 +3,30 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.48.0';
 const SUPABASE_URL = 'https://ezcxfobjsvomcjuwbgep.supabase.co';
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV6Y3hmb2Jqc3ZvbWNqdXdiZ2VwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc2NzQ3ODcsImV4cCI6MjA3MzI1MDc4N30.IhYZYfB_N2JDOG82NFbB_wxY7BJhahqJd9Y71nhpI3I';
 
+const noCacheFetch = (input, init = {}) => {
+  const headers = new Headers(init.headers || {});
+  headers.set('Cache-Control', 'no-store');
+  headers.set('Pragma', 'no-cache');
+  headers.set('Expires', '0');
+
+  return fetch(input, {
+    ...init,
+    cache: 'no-store',
+    headers
+  });
+};
+
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {
     persistSession: false
+  },
+  global: {
+    headers: {
+      'Cache-Control': 'no-store',
+      Pragma: 'no-cache',
+      Expires: '0'
+    },
+    fetch: noCacheFetch
   }
 });
 


### PR DESCRIPTION
## Summary
- add no-cache meta headers to the HTML document to avoid browser caching during development
- wrap Supabase fetch calls to force `cache: no-store` and propagate matching headers for every request

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ebcf864ed4832ba408a03ec8f2ab3c