### PR TITLE
Refactor Supabase setup

### DIFF
--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -1,20 +1,50 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.48.0';
 
-const SUPABASE_URL = 'https://gizddlytlnnkvlgpvkcs.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdpemRkbHl0bG5ua3ZsZ3B2a2NzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjAyNzQ4OTEsImV4cCI6MjA3NTg1MDg5MX0.F8cRkJC5pq0O9eG-hL89Y33ga56AXd-moaSlOtpOg3A';
+/**
+ * Resolve the Supabase configuration.
+ *
+ * The configuration can be provided in three ways (priority order):
+ *  1. Via a global `window.__SUPABASE_CONFIG__` object (useful for deployments).
+ *  2. Via environment variables injected at build time.
+ *  3. Falling back to the default development credentials that ship with the repo.
+ */
+function resolveSupabaseConfig() {
+  const globalConfig = typeof window !== 'undefined' ? window.__SUPABASE_CONFIG__ : undefined;
 
-const noCacheFetch = (input, init = {}) => {
-  const headers = new Headers(init.headers || {});
-  headers.set('Cache-Control', 'no-store');
-  headers.set('Pragma', 'no-cache');
-  headers.set('Expires', '0');
+  const url =
+    globalConfig?.url ||
+    (typeof process !== 'undefined' ? process.env?.SUPABASE_URL : undefined) ||
+    'https://gizddlytlnnkvlgpvkcs.supabase.co';
 
-  return fetch(input, {
-    ...init,
-    cache: 'no-store',
-    headers
-  });
-};
+  const anonKey =
+    globalConfig?.anonKey ||
+    (typeof process !== 'undefined' ? process.env?.SUPABASE_ANON_KEY : undefined) ||
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdpemRkbHl0bG5ua3ZsZ3B2a2NzIiwi' +
+      'cm9sZSI6ImFub24iLCJpYXQiOjE3NjAyNzQ4OTEsImV4cCI6MjA3NTg1MDg5MX0.F8cRkJC5pq0O9eG-hL89Y33ga56AXd-moaSlOtpOg3A';
+
+  if (!url || !anonKey) {
+    throw new Error('Supabase configuratie ontbreekt. Controleer de URL en anon key.');
+  }
+
+  return { url, anonKey };
+}
+
+function createNoCacheFetch() {
+  return (input, init = {}) => {
+    const headers = new Headers(init.headers || {});
+    headers.set('Cache-Control', 'no-store');
+    headers.set('Pragma', 'no-cache');
+    headers.set('Expires', '0');
+
+    return fetch(input, {
+      ...init,
+      cache: 'no-store',
+      headers
+    });
+  };
+}
+
+const { url: SUPABASE_URL, anonKey: SUPABASE_ANON_KEY } = resolveSupabaseConfig();
 
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {
@@ -28,29 +58,18 @@ export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
       Pragma: 'no-cache',
       Expires: '0'
     },
-    fetch: noCacheFetch
+    fetch: createNoCacheFetch()
   }
 });
 
-export async function fetchLocations() {
-  const { data, error } = await supabase
-    .from('locations_with_all')
-    .select('name')
-    .order('name');
-
-  if (error) throw error;
-
-  const names = (data || []).map(location => location.name);
-  const unique = Array.from(new Set(names.filter(Boolean)));
-  if (!unique.includes('Alle locaties')) {
-    unique.unshift('Alle locaties');
-  }
-
-  return unique;
+function toNumber(value) {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
 }
 
-function mapContract(rawContract) {
-  const contract = Array.isArray(rawContract) ? rawContract[0] : rawContract;
+function normaliseContract(contractLike) {
+  const contract = Array.isArray(contractLike) ? contractLike[0] : contractLike;
   if (!contract) {
     return {
       nummer: '—',
@@ -62,23 +81,18 @@ function mapContract(rawContract) {
     };
   }
 
-  const hoursRaw = contract.hours_per_year;
-  const hoursNumber =
-    typeof hoursRaw === 'number' ? hoursRaw : Number(hoursRaw);
-  const uren = Number.isFinite(hoursNumber) ? hoursNumber : null;
-
   return {
     nummer: contract.contract_number ?? '—',
     start: contract.start_date ?? null,
     eind: contract.end_date ?? null,
-    uren,
+    uren: toNumber(contract.hours_per_year),
     type: contract.contract_type ?? '—',
     model: contract.model ?? '—'
   };
 }
 
-function mapActivity(rawActivity = []) {
-  return rawActivity
+function normaliseActivity(activity = []) {
+  return activity
     .map(item => ({
       id: item.activity_code ?? '—',
       type: item.activity_type ?? 'Onbekend',
@@ -89,22 +103,33 @@ function mapActivity(rawActivity = []) {
     .sort((a, b) => new Date(b.date || 0) - new Date(a.date || 0));
 }
 
+export async function fetchLocations() {
+  const { data, error } = await supabase
+    .from('locations_with_all')
+    .select('id, name')
+    .order('name');
+
+  if (error) throw error;
+
+  const uniqueNames = [];
+  const seen = new Set();
+
+  for (const location of data || []) {
+    const name = location?.name;
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    uniqueNames.push(name);
+  }
+
+  return seen.has('Alle locaties')
+    ? uniqueNames
+    : ['Alle locaties', ...uniqueNames];
+}
+
 export async function fetchFleet() {
   const { data, error } = await supabase
-    .from('fleet_assets')
-    .select(`
-      id,
-      reference,
-      model,
-      bmw_status,
-      bmw_expiry,
-      odo,
-      odo_date,
-      active,
-      location:location_id ( name ),
-      contract:fleet_contracts ( contract_number, start_date, end_date, hours_per_year, contract_type, model ),
-      activity:fleet_activity ( activity_code, activity_type, description, status, activity_date )
-    `)
+    .from('fleet_assets_overview')
+    .select('*')
     .order('id');
 
   if (error) throw error;
@@ -115,15 +140,11 @@ export async function fetchFleet() {
     model: item.model ?? '—',
     bmwStatus: item.bmw_status ?? 'Onbekend',
     bmwExpiry: item.bmw_expiry ?? null,
-    odo: (() => {
-      const raw = item.odo;
-      const value = typeof raw === 'number' ? raw : Number(raw);
-      return Number.isFinite(value) ? value : null;
-    })(),
+    odo: toNumber(item.odo),
     odoDate: item.odo_date ?? null,
-    location: item.location?.name ?? 'Onbekende locatie',
-    activity: mapActivity(item.activity),
-    contract: mapContract(item.contract),
+    location: item.location_name ?? 'Onbekende locatie',
+    activity: normaliseActivity(item.activity ?? []),
+    contract: normaliseContract(item.contract),
     active: item.active ?? true
   }));
 }
@@ -131,14 +152,7 @@ export async function fetchFleet() {
 export async function fetchUsers() {
   const { data, error } = await supabase
     .from('motrac_service_portaal_user_directory')
-    .select(`
-      id,
-      display_name,
-      email,
-      phone,
-      role,
-      default_location_name
-    `)
+    .select('id, display_name, email, phone, role, default_location_name')
     .order('display_name');
 
   if (error) throw error;


### PR DESCRIPTION
## Summary
- rebuild the Supabase client with configurable credentials, stricter normalisation and a consolidated fleet view
- redesign the SQL schema to add RLS policies, CRUD permissions and a fleet overview view for the frontend

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ece7a09b68832b83542d5e65a3f26d