### PR TITLE
Add Supabase authenticated login experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,8 +33,54 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body class="bg-motrac-gray text-gray-900">
+  <!-- Login Page -->
+  <div id="loginPage" class="min-h-screen flex items-center justify-center px-4 py-10">
+    <div class="w-full max-w-md bg-white rounded-xl shadow-soft p-8 space-y-6">
+      <div class="flex items-center gap-3">
+        <div class="w-10 h-10 bg-motrac-red rounded-lg"></div>
+        <div>
+          <h1 class="text-xl font-semibold">Motrac Serviceportal</h1>
+          <p class="text-sm text-gray-500">Log in met uw account</p>
+        </div>
+      </div>
+      <form id="loginForm" class="space-y-5">
+        <div>
+          <label for="loginEmail" class="block text-sm font-medium text-gray-700">E-mailadres</label>
+          <input
+            id="loginEmail"
+            type="email"
+            autocomplete="email"
+            required
+            class="mt-1 w-full border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-motrac-red focus:border-transparent"
+          />
+        </div>
+        <div>
+          <label for="loginPassword" class="block text-sm font-medium text-gray-700">Wachtwoord</label>
+          <input
+            id="loginPassword"
+            type="password"
+            autocomplete="current-password"
+            required
+            class="mt-1 w-full border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-motrac-red focus:border-transparent"
+          />
+        </div>
+        <p id="loginStatus" class="text-sm text-gray-500 hidden"></p>
+        <p id="loginError" class="text-sm text-red-600 hidden"></p>
+        <button
+          id="loginSubmit"
+          type="submit"
+          class="w-full inline-flex items-center justify-center gap-2 bg-motrac-red text-white px-4 py-2 rounded-lg font-medium hover:opacity-95 disabled:opacity-70 disabled:cursor-not-allowed"
+        >
+          <span id="loginSubmitDefault">Inloggen</span>
+          <span id="loginSubmitLoading" class="hidden">Bezig…</span>
+        </button>
+      </form>
+      <p class="text-xs text-gray-400 text-center">Toegang uitsluitend voor geautoriseerde Motrac klanten.</p>
+    </div>
+  </div>
+
   <!-- Global App Wrapper -->
-  <div id="app" class="min-h-screen">
+  <div id="app" class="min-h-screen hidden">
     <!-- Top Navigation -->
     <header class="bg-white shadow-soft">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center gap-4">
@@ -59,12 +105,16 @@
           <div class="relative">
             <button id="userBtn" class="flex items-center gap-3 px-3 py-2 bg-gray-100 rounded-lg">
               <span class="h-2 w-2 bg-green-500 rounded-full"></span>
-              <span id="currentUserName" class="text-sm">Test User 2</span>
+              <span id="currentUserName" class="text-sm">Niet ingelogd</span>
               <span>⋯</span>
             </button>
-            <div id="userMenu" class="absolute right-0 mt-2 w-40 bg-white border rounded-lg shadow-soft hidden">
-              <button class="w-full text-left px-4 py-2 hover:bg-gray-50" id="logoutBtn">Logout</button>
-              <button class="w-full text-left px-4 py-2 hover:bg-gray-50" id="cancelUserMenu">Cancel</button>
+            <div id="userMenu" class="absolute right-0 mt-2 w-56 bg-white border rounded-lg shadow-soft hidden">
+              <div class="px-4 py-3 border-b">
+                <p class="text-sm font-semibold" id="userMenuName">Niet ingelogd</p>
+                <p class="text-xs text-gray-500" id="userMenuEmail"></p>
+              </div>
+              <button class="w-full text-left px-4 py-2 hover:bg-gray-50" id="logoutBtn">Uitloggen</button>
+              <button class="w-full text-left px-4 py-2 hover:bg-gray-50" id="cancelUserMenu">Annuleren</button>
             </div>
           </div>
         </div>

--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -62,6 +62,27 @@ export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   }
 });
 
+export async function getCurrentSession() {
+  const result = await supabase.auth.getSession();
+  if (result.error) throw result.error;
+  return result.data;
+}
+
+export function onAuthStateChange(callback) {
+  return supabase.auth.onAuthStateChange(callback);
+}
+
+export async function signInWithPassword({ email, password }) {
+  const result = await supabase.auth.signInWithPassword({ email, password });
+  if (result.error) throw result.error;
+  return result.data;
+}
+
+export async function signOut() {
+  const { error } = await supabase.auth.signOut();
+  if (error) throw error;
+}
+
 function toNumber(value) {
   if (typeof value === 'number') return Number.isFinite(value) ? value : null;
   const numeric = Number(value);
@@ -165,4 +186,24 @@ export async function fetchUsers() {
     location: user.default_location_name ?? '—',
     role: user.role ?? 'Gebruiker'
   }));
+}
+
+export async function fetchProfileByAuthUserId(authUserId) {
+  if (!authUserId) return null;
+
+  const { data, error } = await supabase
+    .from('motrac_service_portaal_user_directory')
+    .select(
+      'id, auth_user_id, display_name, email, phone, role, default_location_id, default_location_name, last_sign_in_at'
+    )
+    .eq('auth_user_id', authUserId)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data ?? null;
+}
+
+export async function touchProfileSignIn() {
+  const { error } = await supabase.rpc('touch_portal_profile_last_sign_in');
+  if (error) throw error;
 }

--- a/src/state.js
+++ b/src/state.js
@@ -3,5 +3,9 @@ export const state = {
   selectedTruckId: null,
   usersPage: 1,
   usersPageSize: 10,
-  editUserId: null
+  editUserId: null,
+  session: null,
+  profile: null,
+  hasLoadedInitialData: false,
+  eventsWired: false
 };


### PR DESCRIPTION
## Summary
- add a dedicated Supabase-powered login screen and guard the application shell behind authentication
- update the frontend session handling to load data only after sign-in and surface current user details
- extend the Supabase schema with profile sync triggers, secure RLS policies, and helpers for tracking last sign-ins

## Testing
- Not run (prototype)

------
https://chatgpt.com/codex/tasks/task_e_68ece9a72778832ba6dbf6c4e1c1315b