### PR TITLE
Restrict customer access to assigned fleet

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
             <thead>
               <tr class="text-left text-gray-600 border-b">
                 <th class="py-3 px-3">Serienummer / Referentie</th>
+                <th class="py-3 px-3">Vloot</th>
                 <th class="py-3 px-3">Model</th>
                 <th class="py-3 px-3">BMWT‑status</th>
                 <th class="py-3 px-3">BMWT‑vervaldatum</th>
@@ -390,6 +391,7 @@
           <select id="userRole" class="mt-1 w-full border rounded-lg px-3 py-2">
             <option>Gebruiker</option>
             <option>Beheerder</option>
+            <option>Klant</option>
           </select>
         </div>
       </div>

--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -157,6 +157,8 @@ export async function fetchFleet() {
 
   return (data || []).map(item => ({
     id: item.id,
+    fleetId: item.customer_fleet_id ?? null,
+    fleetName: item.customer_fleet_name ?? '—',
     ref: item.reference ?? '—',
     model: item.model ?? '—',
     bmwStatus: item.bmw_status ?? 'Onbekend',
@@ -206,4 +208,20 @@ export async function fetchProfileByAuthUserId(authUserId) {
 export async function touchProfileSignIn() {
   const { error } = await supabase.rpc('touch_portal_profile_last_sign_in');
   if (error) throw error;
+}
+
+export async function fetchFleetMemberships(profileId) {
+  if (!profileId) return [];
+
+  const { data, error } = await supabase
+    .from('motrac_service_portaal_profile_fleet_memberships')
+    .select('customer_fleet_id, customer_fleet_name')
+    .eq('profile_id', profileId);
+
+  if (error) throw error;
+
+  return (data || []).map(item => ({
+    fleetId: item.customer_fleet_id ?? null,
+    fleetName: item.customer_fleet_name ?? '—'
+  }));
 }

--- a/src/data.js
+++ b/src/data.js
@@ -2,7 +2,13 @@ const DEFAULT_LOCATIONS = [
   'Alle locaties',
   'Demovloot Motrac – Almere',
   'Demovloot Motrac – Venlo',
-  'Demovloot Motrac – Zwijndrecht'
+  'Demovloot Motrac – Zwijndrecht',
+  'Van Dijk Logistics – Rotterdam'
+];
+
+const DEFAULT_CUSTOMER_FLEETS = [
+  { id: 'CF-DEMO', name: 'Motrac Demovloot' },
+  { id: 'CF-VANDIJK', name: 'Van Dijk Logistics' }
 ];
 
 const DEFAULT_FLEET = [
@@ -15,6 +21,7 @@ const DEFAULT_FLEET = [
     odo: 1523,
     odoDate: '2025-09-28',
     location: 'Demovloot Motrac – Almere',
+    fleetId: 'CF-DEMO',
     activity: [
       { id: 'M-1001', type: 'Onderhoud', desc: 'Periodieke servicebeurt', status: 'Afgerond', date: '2025-06-20' },
       { id: 'M-1010', type: 'Storing', desc: 'Mast-sensor foutcode', status: 'Open', date: '2025-10-01' }
@@ -38,6 +45,7 @@ const DEFAULT_FLEET = [
     odo: 3420,
     odoDate: '2025-09-10',
     location: 'Demovloot Motrac – Zwijndrecht',
+    fleetId: 'CF-DEMO',
     activity: [],
     contract: {
       nummer: 'CTR-2022-ZWD-019',
@@ -57,7 +65,8 @@ const DEFAULT_FLEET = [
     bmwExpiry: '2025-09-01',
     odo: 801,
     odoDate: '2025-09-30',
-    location: 'Demovloot Motrac – Venlo',
+    location: 'Van Dijk Logistics – Rotterdam',
+    fleetId: 'CF-VANDIJK',
     activity: [
       { id: 'M-1020', type: 'Schade', desc: 'Vork beschadigd', status: 'Open', date: '2025-10-03' }
     ],
@@ -84,12 +93,14 @@ const DEFAULT_USERS = [
   { id: 'U8', name: 'Peter Groen', email: 'p.groen@example.com', phone: '+31 6 44445555', location: 'Demovloot Motrac – Venlo', role: 'Gebruiker' },
   { id: 'U9', name: 'Laura Kok', email: 'l.kok@example.com', phone: '+31 6 55556666', location: 'Demovloot Motrac – Almere', role: 'Gebruiker' },
   { id: 'U10', name: 'William de Vries', email: 'w.vries@example.com', phone: '+31 6 66667777', location: 'Demovloot Motrac – Zwijndrecht', role: 'Gebruiker' },
-  { id: 'U11', name: 'Noa Willems', email: 'n.willems@example.com', phone: '+31 6 77778888', location: 'Demovloot Motrac – Almere', role: 'Gebruiker' }
+  { id: 'U11', name: 'Noa Willems', email: 'n.willems@example.com', phone: '+31 6 77778888', location: 'Demovloot Motrac – Almere', role: 'Gebruiker' },
+  { id: 'U12', name: 'Anja van Dijk', email: 'a.vandijk@vandijklogistics.nl', phone: '+31 6 88889999', location: 'Van Dijk Logistics – Rotterdam', role: 'Klant' }
 ];
 
 export let LOCATIONS = [...DEFAULT_LOCATIONS];
 export let FLEET = DEFAULT_FLEET.map(item => ({
   ...item,
+  fleetName: DEFAULT_CUSTOMER_FLEETS.find(fleet => fleet.id === item.fleetId)?.name || '—',
   activity: item.activity.map(activity => ({ ...activity }))
 }));
 export let USERS = [...DEFAULT_USERS];
@@ -104,9 +115,21 @@ export function setLocations(locations = []) {
 }
 
 export function setFleet(fleet = []) {
-  if (Array.isArray(fleet)) {
-    FLEET = fleet;
+  if (!Array.isArray(fleet)) {
+    return;
   }
+
+  FLEET = fleet.map(item => ({
+    ...item,
+    fleetId: item.fleetId || item.customerFleetId || item.customer_fleet_id || null,
+    fleetName:
+      item.fleetName ||
+      item.customerFleetName ||
+      item.customer_fleet_name ||
+      (item.fleetId ? DEFAULT_CUSTOMER_FLEETS.find(fleetDef => fleetDef.id === item.fleetId)?.name : '—') ||
+      '—',
+    activity: Array.isArray(item.activity) ? item.activity.map(activity => ({ ...activity })) : []
+  }));
 }
 
 export function setUsers(users = []) {
@@ -119,6 +142,7 @@ export function resetToDefaults() {
   LOCATIONS = [...DEFAULT_LOCATIONS];
   FLEET = DEFAULT_FLEET.map(item => ({
     ...item,
+    fleetName: DEFAULT_CUSTOMER_FLEETS.find(fleet => fleet.id === item.fleetId)?.name || '—',
     activity: item.activity.map(activity => ({ ...activity }))
   }));
   USERS = [...DEFAULT_USERS];

--- a/src/modules/access.js
+++ b/src/modules/access.js
@@ -1,0 +1,50 @@
+import { state } from '../state.js';
+
+function getRole() {
+  return state.profile?.role ?? null;
+}
+
+function getAllowedFleetIds() {
+  const allowed = state.accessibleFleetIds;
+  return allowed instanceof Set ? allowed : null;
+}
+
+export function canViewFleetAsset(truck) {
+  if (!truck) return false;
+  const role = getRole();
+  if (!role || role === 'Beheerder' || role === 'Gebruiker') {
+    return true;
+  }
+
+  const allowed = getAllowedFleetIds();
+  if (!allowed) {
+    // If we have no allow-list for restricted roles we consider the asset hidden.
+    return role !== 'Klant';
+  }
+
+  if (allowed.size === 0) {
+    return false;
+  }
+
+  if (!truck.fleetId) {
+    return false;
+  }
+
+  return allowed.has(truck.fleetId);
+}
+
+export function filterFleetByAccess(fleet = []) {
+  return fleet.filter(truck => canViewFleetAsset(truck));
+}
+
+export function ensureAccessibleLocation(currentLocation, availableLocations = []) {
+  if (!availableLocations.length) {
+    return 'Alle locaties';
+  }
+
+  if (availableLocations.includes(currentLocation)) {
+    return currentLocation;
+  }
+
+  return availableLocations.includes('Alle locaties') ? 'Alle locaties' : availableLocations[0];
+}

--- a/src/modules/activity.js
+++ b/src/modules/activity.js
@@ -1,5 +1,6 @@
 import { FLEET } from '../data.js';
 import { $, fmtDate } from '../utils.js';
+import { filterFleetByAccess } from './access.js';
 
 export function renderActivity() {
   const container = $('#activityList');
@@ -7,7 +8,7 @@ export function renderActivity() {
   const location = $('#activityLocationFilter').value;
   const items = [];
 
-  FLEET.forEach(truck => {
+  filterFleetByAccess(FLEET).forEach(truck => {
     if (!truck.active) return;
     if (location !== 'Alle locaties' && truck.location !== location) return;
     truck.activity.forEach(activity => {

--- a/src/modules/detail.js
+++ b/src/modules/detail.js
@@ -1,11 +1,12 @@
 import { FLEET } from '../data.js';
 import { state } from '../state.js';
 import { $, $$, fmtDate, kv, formatOdoHtml } from '../utils.js';
+import { canViewFleetAsset } from './access.js';
 
 export function openDetail(id) {
   state.selectedTruckId = id;
   const truck = FLEET.find(item => item.id === id);
-  if (!truck) return;
+  if (!truck || !canViewFleetAsset(truck)) return;
 
   $('#detailTitle').textContent = `${truck.id} • ${truck.ref}`;
   setDetailTab('info');
@@ -22,13 +23,14 @@ export function setDetailTab(tab) {
   });
 
   const truck = FLEET.find(item => item.id === state.selectedTruckId);
-  if (!truck) return;
+  if (!truck || !canViewFleetAsset(truck)) return;
 
   if (tab === 'info') {
     $('#detailContent').innerHTML = `
       <div class="grid sm:grid-cols-2 gap-4 text-sm">
         ${infoRow('Objectnummer', truck.id, true)}
         ${infoRow('Referentie', truck.ref, false, 'editRefFromDetail')}
+        ${infoRow('Vloot', truck.fleetName || '—', true)}
         ${infoRow('Model', truck.model)}
         ${infoRow('Tellerstand (datum)', formatOdoHtml(truck.odo, truck.odoDate), false, 'updateOdoFromDetail')}
         ${infoRow('BMWT‑status', truck.bmwStatus)}

--- a/src/state.js
+++ b/src/state.js
@@ -6,6 +6,7 @@ export const state = {
   editUserId: null,
   session: null,
   profile: null,
+  accessibleFleetIds: null,
   hasLoadedInitialData: false,
   eventsWired: false
 };


### PR DESCRIPTION
## Summary
- add membership-aware access control in the client so customers only see and manage assets from their own fleet
- extend default data and Supabase schema with customer fleet groupings and per-profile memberships
- expose fleet context in the UI with a fleet column and customer role option while guarding sensitive actions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ecf104b4cc832bb5543dd12309c360