### PR TITLE
Replace placeholder logo with forklift icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,25 @@
   <div id="loginPage" class="min-h-screen flex items-center justify-center px-4 py-10">
     <div class="w-full max-w-md bg-white rounded-xl shadow-soft p-8 space-y-6">
       <div class="flex items-center gap-3">
-        <div class="w-10 h-10 bg-motrac-red rounded-lg"></div>
+        <div class="w-10 h-10 bg-motrac-red rounded-lg flex items-center justify-center">
+          <svg
+            class="w-7 h-7 text-white"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="7.5" cy="17.5" r="2.5" />
+            <circle cx="16.5" cy="17.5" r="2.5" />
+            <path d="M4 17.5V14a3 3 0 0 1 3-3h4.5l2 4h3.5" />
+            <path d="M3 17.5h18" />
+            <path d="M14.5 6.5h2l2 6v5" />
+            <path d="M8.5 6.5v4.5" />
+          </svg>
+        </div>
         <div>
           <h1 class="text-xl font-semibold">Motrac Serviceportal</h1>
           <p class="text-sm text-gray-500">Log in met uw account</p>
@@ -85,7 +103,25 @@
     <header class="bg-white shadow-soft">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center gap-4">
         <div class="flex items-center gap-3">
-          <div class="w-9 h-9 bg-motrac-red rounded-lg"></div>
+          <div class="w-9 h-9 bg-motrac-red rounded-lg flex items-center justify-center">
+            <svg
+              class="w-6 h-6 text-white"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="7.5" cy="17.5" r="2.5" />
+              <circle cx="16.5" cy="17.5" r="2.5" />
+              <path d="M4 17.5V14a3 3 0 0 1 3-3h4.5l2 4h3.5" />
+              <path d="M3 17.5h18" />
+              <path d="M14.5 6.5h2l2 6v5" />
+              <path d="M8.5 6.5v4.5" />
+            </svg>
+          </div>
           <div class="leading-tight">
             <h1 class="font-semibold">Motrac Serviceportal</h1>
             <p class="text-xs text-gray-500">Prototype • geen echte data</p>


### PR DESCRIPTION
## Summary
- replace the placeholder red square logo with a reusable inline forklift SVG icon on the login and main navigation headers

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ecf7e0a130832bb58dee65006f72b3