### PR TITLE
Fix account request modal activation on login page

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -630,8 +630,14 @@ async function handleAuthenticatedSession(session, { forceReload = false } = {})
     state.activeEnvironmentKey = 'beheerder';
     state.activeTab = 'vloot';
     $('#currentUserName').textContent = 'Niet ingelogd';
-    $('#userMenuName')?.textContent = 'Niet ingelogd';
-    $('#userMenuEmail')?.textContent = '';
+    const userMenuName = $('#userMenuName');
+    if (userMenuName) {
+      userMenuName.textContent = 'Niet ingelogd';
+    }
+    const userMenuEmail = $('#userMenuEmail');
+    if (userMenuEmail) {
+      userMenuEmail.textContent = '';
+    }
     showLoginPage();
     return;
   }
@@ -654,8 +660,14 @@ async function handleAuthenticatedSession(session, { forceReload = false } = {})
   const displayName =
     profile?.display_name || session.user.user_metadata?.full_name || session.user.email || 'Ingelogde gebruiker';
   $('#currentUserName').textContent = displayName;
-  $('#userMenuName')?.textContent = displayName;
-  $('#userMenuEmail')?.textContent = profile?.email || session.user.email || '';
+  const userMenuName = $('#userMenuName');
+  if (userMenuName) {
+    userMenuName.textContent = displayName;
+  }
+  const userMenuEmail = $('#userMenuEmail');
+  if (userMenuEmail) {
+    userMenuEmail.textContent = profile?.email || session.user.email || '';
+  }
 
   if (forceReload) {
     try {


### PR DESCRIPTION
## Summary
- fix the invalid optional chaining assignments that prevented `main.js` from executing in the browser
- ensure the "Nieuw account aanvragen" button opens the account request modal again

## Testing
- Manual verification in Playwright (modal opens as expected)


------
https://chatgpt.com/codex/tasks/task_e_68ed0bf8fa50832bbe3596020de89c87