### PR TITLE
Restrict portal access until role assignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,21 +514,15 @@
             <label class="block text-sm text-gray-600">Telefoonnummer</label>
             <input id="requestPhone" type="tel" class="mt-1 w-full border rounded-lg px-3 py-2" placeholder="Optioneel" />
           </div>
-          <div>
-            <label class="block text-sm text-gray-600">Gewenste omgeving</label>
-            <select id="requestRole" class="mt-1 w-full border rounded-lg px-3 py-2">
-              <option>Gebruiker</option>
-              <option>Vlootbeheerder</option>
-              <option>Klant</option>
-            </select>
-          </div>
-          <div>
+          <div class="sm:col-span-2">
             <label class="block text-sm text-gray-600">Aanvullende informatie</label>
             <input id="requestNotes" type="text" class="mt-1 w-full border rounded-lg px-3 py-2" placeholder="Bijv. klantnummer" />
           </div>
         </div>
         <p class="text-xs text-gray-500">
-          Na verzenden ontvangt een Motrac beheerder de aanvraag en koppelt het juiste portaal aan uw organisatie.
+          Na verzenden ontvangt een Motrac beheerder de aanvraag en koppelt de juiste rechten aan uw account.
+          U kunt direct inloggen met het gekozen wachtwoord, maar ziet pas inhoud zodra een beheerder uw rol heeft
+          toegewezen.
         </p>
         <div class="flex justify-end gap-2">
           <button type="button" data-close class="px-4 py-2 border rounded-lg">Annuleren</button>

--- a/src/environment.js
+++ b/src/environment.js
@@ -6,6 +6,12 @@ const ROLE_TO_ENVIRONMENT = {
 };
 
 export const ENVIRONMENTS = {
+  pending: {
+    key: 'pending',
+    label: 'Nog geen rol',
+    summary: 'Uw account is aangemaakt. Een beheerder kent binnenkort de juiste rechten toe.',
+    allowedTabs: []
+  },
   beheerder: {
     key: 'beheerder',
     label: 'Beheerder',
@@ -33,13 +39,13 @@ export const ENVIRONMENTS = {
 };
 
 export function getEnvironmentKeyForRole(role) {
-  if (!role) return 'gebruiker';
+  if (!role) return 'pending';
   return ROLE_TO_ENVIRONMENT[role] || 'gebruiker';
 }
 
 export function resolveEnvironment(input) {
   if (!input) {
-    return ENVIRONMENTS.gebruiker;
+    return ENVIRONMENTS.pending;
   }
 
   if (ENVIRONMENTS[input]) {
@@ -47,7 +53,7 @@ export function resolveEnvironment(input) {
   }
 
   const key = getEnvironmentKeyForRole(input);
-  return ENVIRONMENTS[key] || ENVIRONMENTS.gebruiker;
+  return ENVIRONMENTS[key] || ENVIRONMENTS.pending;
 }
 
 export function isTabAllowed(environment, tab) {

--- a/src/main.js
+++ b/src/main.js
@@ -25,9 +25,14 @@ function getFleetSummaryById(fleetId) {
 }
 
 function switchMainTab(tab) {
-  const allowedTabs = Array.isArray(state.allowedTabs) && state.allowedTabs.length
-    ? state.allowedTabs
-    : ['vloot', 'activiteit', 'users'];
+  const allowedTabs = Array.isArray(state.allowedTabs) ? state.allowedTabs : ['vloot', 'activiteit', 'users'];
+
+  if (!allowedTabs.length) {
+    state.activeTab = null;
+    setMainTab(null);
+    return;
+  }
+
   const fallback = allowedTabs[0] || 'vloot';
   const targetTab = allowedTabs.includes(tab) ? tab : fallback;
   state.activeTab = targetTab;
@@ -520,7 +525,6 @@ function handleAccountRequestSubmit(event) {
   const organisation = $('#requestOrganisation')?.value.trim();
   const email = $('#requestEmail')?.value.trim();
   const phone = $('#requestPhone')?.value.trim();
-  const requestedRole = $('#requestRole')?.value || 'Gebruiker';
   const requestNotes = $('#requestNotes')?.value.trim();
 
   if (!name || !organisation || !email) {
@@ -534,7 +538,7 @@ function handleAccountRequestSubmit(event) {
     organisation,
     email,
     phone,
-    requestedRole,
+    requestedRole: null,
     requestNotes,
     status: 'pending',
     submittedAt: new Date().toISOString()
@@ -549,7 +553,7 @@ function handleAccountRequestSubmit(event) {
 
   closeModals();
   renderAccountRequests();
-  showToast('Uw aanvraag is ontvangen. Een beheerder koppelt deze zo snel mogelijk.');
+  showToast('Uw aanvraag is ontvangen. Een beheerder kent binnenkort de juiste rechten toe.');
 }
 
 function handleAccountRequestAction(button) {
@@ -764,7 +768,7 @@ async function loadInitialData(profile) {
   }
 
   const role = profile?.role ?? null;
-  const unrestricted = !role || role === 'Beheerder' || role === 'Gebruiker';
+  const unrestricted = role === 'Beheerder' || role === 'Gebruiker';
   let accessibleFleetIds = unrestricted ? null : new Set();
 
   if (membershipsResult.status === 'fulfilled') {

--- a/src/modules/access.js
+++ b/src/modules/access.js
@@ -12,7 +12,11 @@ function getAllowedFleetIds() {
 export function canViewFleetAsset(truck) {
   if (!truck) return false;
   const role = getRole();
-  if (!role || role === 'Beheerder' || role === 'Gebruiker') {
+  if (!role) {
+    return false;
+  }
+
+  if (role === 'Beheerder' || role === 'Gebruiker') {
     return true;
   }
 

--- a/src/modules/users.js
+++ b/src/modules/users.js
@@ -76,11 +76,11 @@ function renderPendingRequests(listEl, pendingRequests, fleetSummaries) {
 
   listEl.innerHTML = pendingRequests
     .map(request => {
-      const defaultRole = ROLE_OPTIONS.includes(request.requestedRole) ? request.requestedRole : 'Gebruiker';
-      const requestedInfo =
-        request.requestedRole && request.requestedRole !== defaultRole
-          ? `${request.requestedRole}`
-          : defaultRole;
+      const hasRequestedRole = ROLE_OPTIONS.includes(request.requestedRole);
+      const defaultRole = hasRequestedRole ? request.requestedRole : 'Gebruiker';
+      const requestedInfo = hasRequestedRole
+        ? `Voorkeursrol: ${request.requestedRole}`
+        : 'Nog geen rol toegewezen';
       const note = request.requestNotes ? `<p class="text-xs text-gray-500">${request.requestNotes}</p>` : '';
       const contactDetails = [request.email, request.phone].filter(Boolean).join(' • ');
 
@@ -103,7 +103,7 @@ function renderPendingRequests(listEl, pendingRequests, fleetSummaries) {
               <p>${formatDateTime(request.submittedAt)}</p>
             </div>
             <div>
-              <p class="text-xs uppercase text-gray-500 tracking-wide">Gewenste omgeving</p>
+              <p class="text-xs uppercase text-gray-500 tracking-wide">Rolstatus</p>
               <p>${requestedInfo}</p>
             </div>
           </div>

--- a/src/state.js
+++ b/src/state.js
@@ -16,7 +16,7 @@ export const state = {
       email: 'm.hofman@hofmanlogistics.nl',
       phone: '+31 6 9900 1122',
       organisation: 'Hofman Logistics',
-      requestedRole: 'Klant',
+      requestedRole: null,
       requestNotes: 'Klantnummer HL-5582',
       status: 'pending',
       submittedAt: '2025-10-06T09:30:00+02:00'


### PR DESCRIPTION
## Summary
- remove role selection from the account request modal and clarify the onboarding message
- add a "pending" environment so accounts without an assigned role cannot open tabs
- harden access checks and request management to keep data hidden until a role is granted

## Testing
- no tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ed2b5b8064832b9c288dee0256f01c