### PR TITLE
Implement pending account login flow across app and database

### DIFF
--- a/index.html
+++ b/index.html
@@ -520,9 +520,9 @@
           </div>
         </div>
         <p class="text-xs text-gray-500">
-          Na verzenden ontvangt een Motrac beheerder de aanvraag en koppelt de juiste rechten aan uw account.
-          U kunt direct inloggen met het gekozen wachtwoord, maar ziet pas inhoud zodra een beheerder uw rol heeft
-          toegewezen.
+          Na verzenden ontvangt een Motrac beheerder de aanvraag en koppelt de juiste rechten aan uw account. U kunt
+          direct een wachtwoord aanmaken en hiermee inloggen, maar zolang uw account nog in aanvraag is ziet u geen
+          inhoud totdat een beheerder uw rol heeft toegewezen en het account heeft goedgekeurd.
         </p>
         <div class="flex justify-end gap-2">
           <button type="button" data-close class="px-4 py-2 border rounded-lg">Annuleren</button>

--- a/src/environment.js
+++ b/src/environment.js
@@ -2,14 +2,16 @@ const ROLE_TO_ENVIRONMENT = {
   Beheerder: 'beheerder',
   Gebruiker: 'gebruiker',
   Klant: 'klant',
-  Vlootbeheerder: 'vlootbeheerder'
+  Vlootbeheerder: 'vlootbeheerder',
+  Gast: 'pending'
 };
 
 export const ENVIRONMENTS = {
   pending: {
     key: 'pending',
-    label: 'Nog geen rol',
-    summary: 'Uw account is aangemaakt. Een beheerder kent binnenkort de juiste rechten toe.',
+    label: 'Account in aanvraag',
+    summary:
+      'Uw account is actief en u kunt inloggen met uw eigen wachtwoord. Alle inhoud blijft verborgen totdat een beheerder uw rol heeft toegewezen en het account heeft goedgekeurd.',
     allowedTabs: []
   },
   beheerder: {
@@ -40,7 +42,7 @@ export const ENVIRONMENTS = {
 
 export function getEnvironmentKeyForRole(role) {
   if (!role) return 'pending';
-  return ROLE_TO_ENVIRONMENT[role] || 'gebruiker';
+  return ROLE_TO_ENVIRONMENT[role] || 'pending';
 }
 
 export function resolveEnvironment(input) {

--- a/src/modules/users.js
+++ b/src/modules/users.js
@@ -51,11 +51,12 @@ function renderHistory(historyEl, resolvedRequests = []) {
           : 'Afgewezen';
       const fleetLabel =
         request.assignedFleetName || request.organisation || (request.assignedFleetId ? '—' : 'Geen specifieke vloot');
+      const passwordInfo = request.passwordSetAt ? ` • Wachtwoord sinds ${formatDateTime(request.passwordSetAt)}` : '';
       return `
         <div class="flex items-start justify-between gap-3 border border-gray-200 rounded-lg px-3 py-2">
           <div>
             <p class="font-medium text-gray-800">${request.name}</p>
-            <p class="text-xs text-gray-500">${statusLabel} • ${formatDateTime(request.completedAt)}</p>
+            <p class="text-xs text-gray-500">${statusLabel} • ${formatDateTime(request.completedAt)}${passwordInfo}</p>
           </div>
           <span class="text-xs text-gray-500">${fleetLabel}</span>
         </div>`;
@@ -83,6 +84,10 @@ function renderPendingRequests(listEl, pendingRequests, fleetSummaries) {
         : 'Nog geen rol toegewezen';
       const note = request.requestNotes ? `<p class="text-xs text-gray-500">${request.requestNotes}</p>` : '';
       const contactDetails = [request.email, request.phone].filter(Boolean).join(' • ');
+      const loginStatusLabel = request.loginEnabled ? 'Inloggen geactiveerd' : 'Inloggen geblokkeerd';
+      const passwordLabel = request.passwordSetAt
+        ? `Wachtwoord ingesteld op ${formatDateTime(request.passwordSetAt)}`
+        : 'Wachtwoord nog niet ingesteld';
 
       return `
         <article class="border border-gray-200 rounded-lg p-4 space-y-3" data-request data-id="${request.id}">
@@ -105,6 +110,14 @@ function renderPendingRequests(listEl, pendingRequests, fleetSummaries) {
             <div>
               <p class="text-xs uppercase text-gray-500 tracking-wide">Rolstatus</p>
               <p>${requestedInfo}</p>
+            </div>
+            <div>
+              <p class="text-xs uppercase text-gray-500 tracking-wide">Toegang</p>
+              <p>${loginStatusLabel}</p>
+            </div>
+            <div>
+              <p class="text-xs uppercase text-gray-500 tracking-wide">Wachtwoord</p>
+              <p>${passwordLabel}</p>
             </div>
           </div>
           <div class="grid sm:grid-cols-2 gap-3">
@@ -144,7 +157,7 @@ export function renderAccountRequests() {
   const summaryEl = $('#accountRequestsSummary');
   if (summaryEl) {
     summaryEl.textContent = pending.length
-      ? `${pending.length} aanvraag${pending.length > 1 ? 'en' : ''} wachten op toewijzing.`
+      ? `${pending.length} aanvraag${pending.length > 1 ? 'en' : ''} wachten op toewijzing. Aanvragers kunnen al inloggen maar zien nog geen inhoud.`
       : 'Geen open aanvragen.';
   }
 

--- a/src/state.js
+++ b/src/state.js
@@ -9,20 +9,8 @@ export const state = {
   accessibleFleetIds: null,
   hasLoadedInitialData: false,
   eventsWired: false,
-  accountRequests: [
-    {
-      id: 'R1001',
-      name: 'Mila Hofman',
-      email: 'm.hofman@hofmanlogistics.nl',
-      phone: '+31 6 9900 1122',
-      organisation: 'Hofman Logistics',
-      requestedRole: null,
-      requestNotes: 'Klantnummer HL-5582',
-      status: 'pending',
-      submittedAt: '2025-10-06T09:30:00+02:00'
-    }
-  ],
-  activeEnvironmentKey: 'beheerder',
-  allowedTabs: ['vloot', 'activiteit', 'users'],
-  activeTab: 'vloot'
+  accountRequests: [],
+  activeEnvironmentKey: 'pending',
+  allowedTabs: [],
+  activeTab: null
 };


### PR DESCRIPTION
## Summary
- add Supabase schema for managing account requests, login enablement, and password timestamps
- integrate account request submission and approval with Supabase-backed data throughout the app
- surface pending-account messaging in the UI so users know they can log in while content stays hidden

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ed36b2999c832bb33eeb49decb60a2