### PR TITLE
Improve responsive layout for portal

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,8 +108,8 @@
   <div id="app" class="min-h-screen hidden">
     <!-- Top Navigation -->
     <header class="bg-white shadow-soft">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center gap-4">
-        <div class="flex items-center gap-3">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
+        <div class="flex items-center gap-3 order-1 sm:order-1">
           <div class="w-9 h-9 bg-motrac-red rounded-lg flex items-center justify-center">
             <svg
               class="w-6 h-6 text-white"
@@ -134,16 +134,48 @@
             <p class="text-xs text-gray-500">Prototype • geen echte data</p>
           </div>
         </div>
-        <nav class="ml-6 flex-1">
-          <ul class="flex items-center gap-6 text-sm font-medium" id="mainTabs">
-            <li><button data-tab="vloot" class="tab-active py-2">Vloot</button></li>
-            <li><button data-tab="activiteit" class="py-2">Activiteit</button></li>
-            <li><button data-tab="users" class="py-2">Gebruikersbeheer</button></li>
+        <nav
+          id="mainNav"
+          class="order-3 hidden w-full border-t border-gray-100 pt-3 sm:order-2 sm:border-0 sm:pt-0 sm:flex sm:flex-1 sm:items-center sm:gap-6"
+        >
+          <ul class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-6 text-sm font-medium w-full sm:w-auto" id="mainTabs">
+            <li class="w-full sm:w-auto">
+              <button data-tab="vloot" class="tab-active w-full text-left sm:w-auto sm:text-center py-2 px-3">Vloot</button>
+            </li>
+            <li class="w-full sm:w-auto">
+              <button data-tab="activiteit" class="w-full text-left sm:w-auto sm:text-center py-2 px-3">Activiteit</button>
+            </li>
+            <li class="w-full sm:w-auto">
+              <button data-tab="users" class="w-full text-left sm:w-auto sm:text-center py-2 px-3">Gebruikersbeheer</button>
+            </li>
           </ul>
         </nav>
-        <div class="flex items-center gap-2">
-          <button id="btnNewTicket" class="hidden sm:inline-flex items-center gap-2 bg-motrac-red text-white px-4 py-2 rounded-lg hover:opacity-95 shadow-soft">
+        <div class="flex flex-wrap items-center gap-2 ml-auto order-2 sm:order-3 sm:ml-0 sm:justify-end">
+          <button
+            id="btnNewTicketMobile"
+            class="sm:hidden inline-flex items-center gap-2 bg-motrac-red text-white px-3 py-2 rounded-lg shadow-soft"
+            type="button"
+          >
+            <span>Servicemelding</span>
+          </button>
+          <button
+            id="btnNewTicket"
+            class="hidden sm:inline-flex items-center gap-2 bg-motrac-red text-white px-4 py-2 rounded-lg hover:opacity-95 shadow-soft"
+            type="button"
+          >
             <span>Servicemelding maken</span>
+          </button>
+          <button
+            id="mobileMenuToggle"
+            class="sm:hidden inline-flex items-center gap-2 px-3 py-2 border rounded-lg text-sm"
+            type="button"
+            aria-expanded="false"
+            aria-controls="mainNav"
+          >
+            <span>Menu</span>
+            <svg class="w-4 h-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
+              <path d="M3 6h14M3 10h14M3 14h14" stroke-linecap="round" />
+            </svg>
           </button>
           <div class="relative">
             <button id="userBtn" class="flex items-center gap-3 px-3 py-2 bg-gray-100 rounded-lg">
@@ -207,7 +239,7 @@
         </div>
 
         <!-- Table -->
-        <div class="bg-white rounded-xl shadow-soft p-2 overflow-auto">
+        <div class="bg-white rounded-xl shadow-soft p-2 overflow-auto responsive-table">
           <table class="min-w-full text-sm">
             <thead>
               <tr class="text-left text-gray-600 border-b">
@@ -282,7 +314,7 @@
             <div id="accountRequestsHistory" class="mt-2 space-y-2 text-sm text-gray-600"></div>
           </div>
         </div>
-        <div class="bg-white rounded-xl shadow-soft p-2 overflow-auto">
+        <div class="bg-white rounded-xl shadow-soft p-2 overflow-auto responsive-table">
           <table class="min-w-full text-sm">
             <thead>
               <tr class="text-left text-gray-600 border-b">
@@ -305,7 +337,7 @@
 
       <!-- DETAIL: TRUCK -->
       <section id="truckDetail" class="hidden space-y-4">
-        <div class="flex items-center justify-between">
+        <div class="flex flex-wrap items-center justify-between gap-3">
           <div class="flex items-center gap-3">
             <button id="backToFleet" class="px-3 py-2 border rounded-lg">← Terug naar overzicht</button>
             <h2 id="detailTitle" class="text-lg font-semibold"></h2>
@@ -315,6 +347,11 @@
             <button class="px-3 py-2 border rounded-lg" data-action="updateOdo">Tellerstand doorgeven</button>
             <button class="px-3 py-2 border rounded-lg" data-action="editRef">Uw referentie wijzigen</button>
           </div>
+        </div>
+        <div class="grid grid-cols-1 sm:hidden gap-2">
+          <button class="px-3 py-2 border rounded-lg text-sm" data-action="newTicketFromDetail">Melding aanmaken</button>
+          <button class="px-3 py-2 border rounded-lg text-sm" data-action="updateOdo">Tellerstand doorgeven</button>
+          <button class="px-3 py-2 border rounded-lg text-sm" data-action="editRef">Uw referentie wijzigen</button>
         </div>
 
         <div class="bg-white rounded-xl shadow-soft p-0">
@@ -332,7 +369,7 @@
   <!-- MODALS -->
   <!-- Servicemelding algemeen -->
   <div id="modalTicket" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
-    <div class="bg-white w-full max-w-2xl rounded-xl shadow-soft p-6">
+    <div class="bg-white w-full max-w-2xl rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Servicemelding maken</h3>
         <button data-close class="text-gray-500">✕</button>
@@ -373,7 +410,7 @@
 
   <!-- Tellerstand doorgeven -->
   <div id="modalOdo" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
-    <div class="bg-white w-full max-w-md rounded-xl shadow-soft p-6">
+    <div class="bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Tellerstand doorgeven</h3>
         <button data-close class="text-gray-500">✕</button>
@@ -392,7 +429,7 @@
 
   <!-- Referentie wijzigen -->
   <div id="modalRef" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
-    <div class="bg-white w-full max-w-md rounded-xl shadow-soft p-6">
+    <div class="bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Uw referentie wijzigen</h3>
         <button data-close class="text-gray-500">✕</button>
@@ -411,7 +448,7 @@
 
   <!-- Verwijderen uit lijst (inactief) -->
   <div id="modalInactive" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
-    <div class="bg-white w-full max-w-md rounded-xl shadow-soft p-6">
+    <div class="bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Verwijderen uit lijst</h3>
         <button data-close class="text-gray-500">✕</button>
@@ -436,7 +473,7 @@
 
   <!-- Contract inzien -->
   <div id="modalContract" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
-    <div class="bg-white w-full max-w-xl rounded-xl shadow-soft p-6">
+    <div class="bg-white w-full max-w-xl rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Contract</h3>
         <button data-close class="text-gray-500">✕</button>
@@ -450,7 +487,7 @@
 
   <!-- Gebruiker toevoegen/bewerken -->
   <div id="modalUser" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
-    <div class="bg-white w-full max-w-md rounded-xl shadow-soft p-6">
+    <div class="bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 id="userModalTitle" class="text-lg font-semibold">Gebruiker toevoegen</h3>
         <button data-close class="text-gray-500">✕</button>
@@ -491,7 +528,7 @@
 
   <!-- Nieuw account aanvragen -->
   <div id="modalAccountRequest" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
-    <div class="bg-white w-full max-w-lg rounded-xl shadow-soft p-6">
+    <div class="bg-white w-full max-w-lg rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Nieuw account aanvragen</h3>
         <button data-close class="text-gray-500">✕</button>

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -22,6 +22,28 @@ export function wireEvents() {
     });
   }
 
+  const mainNav = $('#mainNav');
+  const mobileMenuToggle = $('#mobileMenuToggle');
+  const collapseMobileMenu = () => {
+    if (!mainNav || !mobileMenuToggle) return;
+    mainNav.classList.add('hidden');
+    mobileMenuToggle.setAttribute('aria-expanded', 'false');
+  };
+
+  mobileMenuToggle?.addEventListener('click', () => {
+    if (!mainNav) return;
+    const isHidden = mainNav.classList.toggle('hidden');
+    mobileMenuToggle.setAttribute('aria-expanded', isHidden ? 'false' : 'true');
+  });
+
+  document.addEventListener('click', event => {
+    if (!mainNav || !mobileMenuToggle) return;
+    if (mainNav.classList.contains('hidden')) return;
+    if (!window.matchMedia('(max-width: 639px)').matches) return;
+    if (event.target.closest('#mainNav') || event.target.closest('#mobileMenuToggle')) return;
+    collapseMobileMenu();
+  });
+
   $('#userBtn').addEventListener('click', () => $('#userMenu').classList.toggle('hidden'));
   $('#cancelUserMenu').addEventListener('click', () => $('#userMenu').classList.add('hidden'));
   document.addEventListener('click', event => {
@@ -40,6 +62,9 @@ export function wireEvents() {
     button.addEventListener('click', () => {
       if (button.disabled) return;
       switchMainTab(button.dataset.tab);
+      if (window.matchMedia('(max-width: 639px)').matches) {
+        collapseMobileMenu();
+      }
     })
   );
 
@@ -163,6 +188,10 @@ export function wireEvents() {
   });
 
   $('#btnNewTicket').addEventListener('click', () => openModal('#modalTicket'));
+  $('#btnNewTicketMobile')?.addEventListener('click', () => {
+    openModal('#modalTicket');
+    collapseMobileMenu();
+  });
   $('#ticketCreate').addEventListener('click', () => {
     const id = $('#ticketTruck').value;
     const type = $('#ticketType').value;

--- a/src/modules/fleet.js
+++ b/src/modules/fleet.js
@@ -45,21 +45,21 @@ export function renderFleet() {
     const openCount = truck.activity.filter(activity => activity.status === 'Open').length;
     return `
       <tr class="border-b hover:bg-gray-50">
-        <td class="py-3 px-3">
+        <td class="py-3 px-3" data-label="Serienummer / Referentie">
           <button class="text-left text-gray-900 hover:underline" data-open-detail="${truck.id}">
             <div class="font-medium">${truck.id}</div>
             <div class="text-xs text-gray-500">${truck.ref}</div>
           </button>
         </td>
-        <td class="py-3 px-3">${truck.fleetName || '—'}</td>
-        <td class="py-3 px-3">${truck.model}</td>
-        <td class="py-3 px-3">${truck.bmwStatus}</td>
-        <td class="py-3 px-3">${fmtDate(truck.bmwExpiry)}</td>
-        <td class="py-3 px-3">${formatOdoHtml(truck.odo, truck.odoDate)}</td>
-        <td class="py-3 px-3">
+        <td class="py-3 px-3" data-label="Vloot">${truck.fleetName || '—'}</td>
+        <td class="py-3 px-3" data-label="Model">${truck.model}</td>
+        <td class="py-3 px-3" data-label="BMWT‑status">${truck.bmwStatus}</td>
+        <td class="py-3 px-3" data-label="BMWT‑vervaldatum">${fmtDate(truck.bmwExpiry)}</td>
+        <td class="py-3 px-3" data-label="Tellerstand (datum)">${formatOdoHtml(truck.odo, truck.odoDate)}</td>
+        <td class="py-3 px-3" data-label="Activiteit">
           <button class="inline-flex items-center justify-center w-7 h-7 bg-red-100 text-motrac-red rounded-full font-semibold" title="Open meldingen" data-open-detail="${truck.id}">${openCount}</button>
         </td>
-        <td class="py-3 px-3 text-right">
+        <td class="py-3 px-3 sm:text-right" data-label="Acties">
           <div class="relative inline-block kebab">
             <button class="px-2 py-1 border rounded-lg">⋮</button>
             <div class="kebab-menu hidden absolute right-0 mt-2 w-56 bg-white border rounded-lg shadow-soft z-10">
@@ -74,5 +74,6 @@ export function renderFleet() {
       </tr>`;
   }).join('');
 
-  $('#fleetTbody').innerHTML = rows || '<tr><td colspan="8" class="py-6 text-center text-gray-500">Geen resultaten</td></tr>';
+  $('#fleetTbody').innerHTML =
+    rows || '<tr><td colspan="8" class="py-6 px-3 text-center text-gray-500">Geen resultaten</td></tr>';
 }

--- a/src/modules/users.js
+++ b/src/modules/users.js
@@ -188,14 +188,14 @@ export function renderUsers() {
 
   $('#usersTbody').innerHTML = pageItems.map(user => `
     <tr class="border-b hover:bg-gray-50">
-      <td class="py-3 px-3">
+      <td class="py-3 px-3" data-label="Gebruiker">
         <div class="font-medium">${user.name}</div>
         <div class="text-xs text-gray-500">${user.phone}</div>
       </td>
-      <td class="py-3 px-3">${user.location}</td>
-      <td class="py-3 px-3">${user.email}</td>
-      <td class="py-3 px-3">${user.role}</td>
-      <td class="py-3 px-3 text-right">
+      <td class="py-3 px-3" data-label="Locatie">${user.location}</td>
+      <td class="py-3 px-3" data-label="Email">${user.email}</td>
+      <td class="py-3 px-3" data-label="Portaalrechten">${user.role}</td>
+      <td class="py-3 px-3 sm:text-right" data-label="Acties">
         <div class="relative inline-block kebab">
           <button class="px-2 py-1 border rounded-lg">⋮</button>
           <div class="kebab-menu hidden absolute right-0 mt-2 w-44 bg-white border rounded-lg shadow-soft z-10">

--- a/styles.css
+++ b/styles.css
@@ -30,7 +30,6 @@
   color: var(--color-on-primary);
   background: var(--color-primary);
   border-radius: var(--radius-sm);
-  padding: 0.25rem 0.75rem;
 }
 
 .modal {
@@ -42,6 +41,13 @@
 
 .modal.show {
   display: flex;
+}
+
+.truncate-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 :root[data-theme="dark"] {
@@ -2529,4 +2535,64 @@ nav.pager select {
     bottom: 1rem;
   }
 }
-:root {
+.responsive-table {
+  overflow-x: auto;
+}
+
+@media (max-width: 640px) {
+  .responsive-table {
+    overflow: visible;
+    padding: 0;
+  }
+
+  .responsive-table table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+  }
+
+  .responsive-table thead {
+    display: none;
+  }
+
+  .responsive-table tbody tr {
+    display: grid;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .responsive-table tbody tr:last-child {
+    border-bottom: none;
+  }
+
+  .responsive-table tbody td {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 0;
+    text-align: left;
+  }
+
+  .responsive-table tbody td::before {
+    content: attr(data-label);
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+
+  .responsive-table tbody td[data-label='Acties'] {
+    align-items: flex-end;
+  }
+
+  .responsive-table tbody td:not([data-label])::before {
+    display: none;
+  }
+
+  .responsive-table tbody td:not([data-label]) {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- restructure the header with a mobile menu toggle and dedicated mobile action button so navigation works on phones
- add responsive table styling and data labels for fleet and user lists to present readable card layouts on small screens
- expose mobile-friendly detail actions and give modals scrollable height limits to avoid clipping on handheld devices

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed5a804c14832b8f33d4302eea8a59