### PR TITLE
Add fleet contract and usage data to overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,12 +244,16 @@
             <thead>
               <tr class="text-left text-gray-600 border-b">
                 <th class="py-3 px-3">Serienummer / Referentie</th>
-                <th class="py-3 px-3">Vloot</th>
+                <th class="py-3 px-3">Modeltype</th>
                 <th class="py-3 px-3">Model</th>
                 <th class="py-3 px-3">BMWT‑status</th>
                 <th class="py-3 px-3">BMWT‑vervaldatum</th>
-                <th class="py-3 px-3">Tellerstand (datum)</th>
-                <th class="py-3 px-3">Activiteit</th>
+                <th class="py-3 px-3">Locatie</th>
+                <th class="py-3 px-3">Urenstand (datum)</th>
+                <th class="py-3 px-3">Contractnummer</th>
+                <th class="py-3 px-3">Contract startdatum</th>
+                <th class="py-3 px-3">Contract einddatum</th>
+                <th class="py-3 px-3">Openstaande meldingen</th>
                 <th class="py-3 px-3 text-right">Acties</th>
               </tr>
             </thead>
@@ -344,13 +348,13 @@
           </div>
           <div class="hidden sm:flex items-center gap-2">
             <button class="px-3 py-2 border rounded-lg" data-action="newTicketFromDetail">Melding aanmaken</button>
-            <button class="px-3 py-2 border rounded-lg" data-action="updateOdo">Tellerstand doorgeven</button>
+            <button class="px-3 py-2 border rounded-lg" data-action="updateOdo">Urenstand doorgeven</button>
             <button class="px-3 py-2 border rounded-lg" data-action="editRef">Uw referentie wijzigen</button>
           </div>
         </div>
         <div class="grid grid-cols-1 sm:hidden gap-2">
           <button class="px-3 py-2 border rounded-lg text-sm" data-action="newTicketFromDetail">Melding aanmaken</button>
-          <button class="px-3 py-2 border rounded-lg text-sm" data-action="updateOdo">Tellerstand doorgeven</button>
+          <button class="px-3 py-2 border rounded-lg text-sm" data-action="updateOdo">Urenstand doorgeven</button>
           <button class="px-3 py-2 border rounded-lg text-sm" data-action="editRef">Uw referentie wijzigen</button>
         </div>
 
@@ -408,16 +412,16 @@
     </div>
   </div>
 
-  <!-- Tellerstand doorgeven -->
+  <!-- Urenstand doorgeven -->
   <div id="modalOdo" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
     <div class="bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
-        <h3 class="text-lg font-semibold">Tellerstand doorgeven</h3>
+        <h3 class="text-lg font-semibold">Urenstand doorgeven</h3>
         <button data-close class="text-gray-500">✕</button>
       </div>
       <div class="space-y-2">
-        <div class="text-sm text-gray-600">Huidige tellerstand: <span id="odoCurrent" class="font-medium text-gray-800">—</span></div>
-        <label class="text-sm text-gray-600">Nieuwe tellerstand</label>
+        <div class="text-sm text-gray-600">Huidige urenstand: <span id="odoCurrent" class="font-medium text-gray-800">—</span></div>
+        <label class="text-sm text-gray-600">Nieuwe urenstand</label>
         <input id="odoNew" type="number" class="w-full border rounded-lg px-3 py-2" />
       </div>
       <div class="mt-6 flex justify-end gap-2">

--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -199,13 +199,20 @@ export async function fetchFleet() {
     fleetName: item.customer_fleet_name ?? '—',
     ref: item.reference ?? '—',
     model: item.model ?? '—',
+    modelType: item.model_type ?? '—',
     bmwStatus: item.bmw_status ?? 'Onbekend',
     bmwExpiry: item.bmw_expiry ?? null,
-    odo: toNumber(item.odo),
-    odoDate: item.odo_date ?? null,
+    hours: toNumber(item.hours ?? item.odo),
+    hoursDate: item.hours_date ?? item.odo_date ?? null,
+    odo: toNumber(item.hours ?? item.odo),
+    odoDate: item.hours_date ?? item.odo_date ?? null,
     location: item.location_name ?? 'Onbekende locatie',
     activity: normaliseActivity(item.activity ?? []),
     contract: normaliseContract(item.contract),
+    openActivityCount: (() => {
+      const value = toNumber(item.open_activity_count);
+      return value == null ? 0 : value;
+    })(),
     active: item.active ?? true
   }));
 }

--- a/src/data.js
+++ b/src/data.js
@@ -16,10 +16,11 @@ const DEFAULT_FLEET = [
     id: 'E16-123456',
     ref: 'Reachtruck – Magazijn A',
     model: 'Linde E16',
+    modelType: 'Elektrische heftruck',
     bmwStatus: 'Goedgekeurd',
     bmwExpiry: '2026-03-15',
-    odo: 1523,
-    odoDate: '2025-09-28',
+    hours: 1523,
+    hoursDate: '2025-09-28',
     location: 'Demovloot Motrac – Almere',
     fleetId: 'CF-DEMO',
     activity: [
@@ -40,10 +41,11 @@ const DEFAULT_FLEET = [
     id: 'H25-654321',
     ref: 'Buiten terrein',
     model: 'Linde H25',
+    modelType: 'Verbranding heftruck',
     bmwStatus: 'Goedgekeurd',
     bmwExpiry: '2025-12-01',
-    odo: 3420,
-    odoDate: '2025-09-10',
+    hours: 3420,
+    hoursDate: '2025-09-10',
     location: 'Demovloot Motrac – Zwijndrecht',
     fleetId: 'CF-DEMO',
     activity: [],
@@ -61,10 +63,11 @@ const DEFAULT_FLEET = [
     id: 'E20-777777',
     ref: 'Productiehal 3',
     model: 'Linde E20',
+    modelType: 'Elektrische heftruck',
     bmwStatus: 'Afkeur',
     bmwExpiry: '2025-09-01',
-    odo: 801,
-    odoDate: '2025-09-30',
+    hours: 801,
+    hoursDate: '2025-09-30',
     location: 'Van Dijk Logistics – Rotterdam',
     fleetId: 'CF-VANDIJK',
     activity: [
@@ -98,12 +101,82 @@ const DEFAULT_USERS = [
   { id: 'U12', name: 'Anja van Dijk', email: 'a.vandijk@vandijklogistics.nl', phone: '+31 6 88889999', location: 'Van Dijk Logistics – Rotterdam', role: 'Klant' }
 ];
 
+function findDefaultFleetName(fleetId) {
+  return DEFAULT_CUSTOMER_FLEETS.find(fleet => fleet.id === fleetId)?.name || '—';
+}
+
+function normaliseContract(contractLike = {}, fallbackModel = '—') {
+  if (!contractLike) {
+    return {
+      nummer: '—',
+      start: null,
+      eind: null,
+      uren: null,
+      type: '—',
+      model: fallbackModel ?? '—'
+    };
+  }
+
+  return {
+    nummer: contractLike.nummer ?? contractLike.contractNumber ?? contractLike.contract_number ?? '—',
+    start: contractLike.start ?? contractLike.startDatum ?? contractLike.start_date ?? null,
+    eind: contractLike.eind ?? contractLike.eindDatum ?? contractLike.end_date ?? null,
+    uren: contractLike.uren ?? contractLike.hoursPerYear ?? contractLike.hours_per_year ?? null,
+    type: contractLike.type ?? contractLike.contractType ?? contractLike.contract_type ?? '—',
+    model: contractLike.model ?? fallbackModel ?? '—'
+  };
+}
+
+function normaliseFleetActivity(activity = []) {
+  return Array.isArray(activity)
+    ? activity.map(entry => ({ ...entry }))
+    : [];
+}
+
+function normaliseFleetItem(item = {}) {
+  const fleetId = item.fleetId || item.customerFleetId || item.customer_fleet_id || null;
+  const activity = normaliseFleetActivity(item.activity);
+  const hoursValue =
+    item.hours ??
+    item.hoursReading ??
+    item.hours_reading ??
+    item.urenstand ??
+    item.odo ??
+    null;
+  const hoursDateValue =
+    item.hoursDate ??
+    item.hours_date ??
+    item.hoursReadingDate ??
+    item.urenstandDatum ??
+    item.urenstand_datum ??
+    item.odoDate ??
+    item.odo_date ??
+    null;
+
+  return {
+    ...item,
+    fleetId,
+    fleetName:
+      item.fleetName ||
+      item.customerFleetName ||
+      item.customer_fleet_name ||
+      (fleetId ? findDefaultFleetName(fleetId) : '—') ||
+      '—',
+    location: item.location || item.location_name || '—',
+    modelType: item.modelType || item.model_type || '—',
+    hours: hoursValue,
+    hoursDate: hoursDateValue,
+    odo: hoursValue,
+    odoDate: hoursDateValue,
+    activity,
+    openActivityCount: activity.filter(entry => entry?.status === 'Open').length,
+    contract: normaliseContract(item.contract, item.model),
+    active: typeof item.active === 'boolean' ? item.active : true
+  };
+}
+
 export let LOCATIONS = [...DEFAULT_LOCATIONS];
-export let FLEET = DEFAULT_FLEET.map(item => ({
-  ...item,
-  fleetName: DEFAULT_CUSTOMER_FLEETS.find(fleet => fleet.id === item.fleetId)?.name || '—',
-  activity: item.activity.map(activity => ({ ...activity }))
-}));
+export let FLEET = DEFAULT_FLEET.map(item => normaliseFleetItem(item));
 export let USERS = [...DEFAULT_USERS];
 
 export function setLocations(locations = []) {
@@ -120,17 +193,7 @@ export function setFleet(fleet = []) {
     return;
   }
 
-  FLEET = fleet.map(item => ({
-    ...item,
-    fleetId: item.fleetId || item.customerFleetId || item.customer_fleet_id || null,
-    fleetName:
-      item.fleetName ||
-      item.customerFleetName ||
-      item.customer_fleet_name ||
-      (item.fleetId ? DEFAULT_CUSTOMER_FLEETS.find(fleetDef => fleetDef.id === item.fleetId)?.name : '—') ||
-      '—',
-    activity: Array.isArray(item.activity) ? item.activity.map(activity => ({ ...activity })) : []
-  }));
+  FLEET = fleet.map(item => normaliseFleetItem(item));
 }
 
 export function setUsers(users = []) {
@@ -141,10 +204,6 @@ export function setUsers(users = []) {
 
 export function resetToDefaults() {
   LOCATIONS = [...DEFAULT_LOCATIONS];
-  FLEET = DEFAULT_FLEET.map(item => ({
-    ...item,
-    fleetName: DEFAULT_CUSTOMER_FLEETS.find(fleet => fleet.id === item.fleetId)?.name || '—',
-    activity: item.activity.map(activity => ({ ...activity }))
-  }));
+  FLEET = DEFAULT_FLEET.map(item => normaliseFleetItem(item));
   USERS = [...DEFAULT_USERS];
 }

--- a/src/modules/detail.js
+++ b/src/modules/detail.js
@@ -1,6 +1,6 @@
 import { FLEET } from '../data.js';
 import { state } from '../state.js';
-import { $, $$, fmtDate, kv, formatOdoHtml } from '../utils.js';
+import { $, $$, fmtDate, kv, formatHoursHtml } from '../utils.js';
 import { canViewFleetAsset } from './access.js';
 
 export function openDetail(id) {
@@ -31,8 +31,10 @@ export function setDetailTab(tab) {
         ${infoRow('Objectnummer', truck.id, true)}
         ${infoRow('Referentie', truck.ref, false, 'editRefFromDetail')}
         ${infoRow('Vloot', truck.fleetName || '—', true)}
+        ${infoRow('Locatie', truck.location || '—', true)}
+        ${infoRow('Modeltype', truck.modelType || '—', true)}
         ${infoRow('Model', truck.model)}
-        ${infoRow('Tellerstand (datum)', formatOdoHtml(truck.odo, truck.odoDate), false, 'updateOdoFromDetail')}
+        ${infoRow('Urenstand (datum)', formatHoursHtml(truck.hours, truck.hoursDate), false, 'updateOdoFromDetail')}
         ${infoRow('BMWT‑status', truck.bmwStatus)}
         ${infoRow('BMWT‑vervaldatum', fmtDate(truck.bmwExpiry))}
       </div>`;

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -1,6 +1,6 @@
 import { FLEET, USERS } from '../data.js';
 import { state } from '../state.js';
-import { $, $$, fmtDate, showToast, openModal, closeModals, kv, formatOdoLabel } from '../utils.js';
+import { $, $$, fmtDate, showToast, openModal, closeModals, kv, formatHoursLabel } from '../utils.js';
 import { renderFleet } from './fleet.js';
 import { renderActivity } from './activity.js';
 import { renderUsers } from './users.js';
@@ -145,7 +145,7 @@ export function wireEvents() {
     if (action === 'updateOdo' || action === 'updateOdoFromDetail') {
       const odoCurrent = $('#odoCurrent');
       if (odoCurrent) {
-        odoCurrent.textContent = formatOdoLabel(truck.odo, truck.odoDate);
+        odoCurrent.textContent = formatHoursLabel(truck.hours, truck.hoursDate);
       }
       const odoInput = $('#odoNew');
       if (odoInput) {
@@ -234,6 +234,7 @@ export function wireEvents() {
       status: 'Open',
       date: new Date().toISOString()
     });
+    truck.openActivityCount = truck.activity.filter(activity => activity?.status === 'Open').length;
 
     closeModals();
     renderFleet();
@@ -255,21 +256,23 @@ export function wireEvents() {
     }
     const odoInput = $('#odoNew');
     if (!odoInput) {
-      showToast('Geen veld voor tellerstand gevonden.');
+      showToast('Geen veld voor urenstand gevonden.');
       return;
     }
     const value = parseInt(odoInput.value, 10);
-    const currentOdo = typeof truck.odo === 'number' && Number.isFinite(truck.odo) ? truck.odo : null;
-    if (Number.isNaN(value) || value < 0 || (currentOdo !== null && value < currentOdo)) {
-      showToast('Nieuwe tellerstand moet ≥ huidige zijn.');
+    const currentHours = typeof truck.hours === 'number' && Number.isFinite(truck.hours) ? truck.hours : null;
+    if (Number.isNaN(value) || value < 0 || (currentHours !== null && value < currentHours)) {
+      showToast('Nieuwe urenstand moet ≥ huidige zijn.');
       return;
     }
+    truck.hours = value;
+    truck.hoursDate = new Date().toISOString();
     truck.odo = value;
-    truck.odoDate = new Date().toISOString();
+    truck.odoDate = truck.hoursDate;
     closeModals();
     renderFleet();
     setDetailTab('info');
-    showToast('Tellerstand bijgewerkt.');
+    showToast('Urenstand bijgewerkt.');
   });
 
   $('#refSave')?.addEventListener('click', event => {

--- a/src/modules/fleet.js
+++ b/src/modules/fleet.js
@@ -1,6 +1,6 @@
 import { LOCATIONS, FLEET } from '../data.js';
 import { state } from '../state.js';
-import { $, fmtDate, formatOdoHtml } from '../utils.js';
+import { $, fmtDate, formatHoursHtml } from '../utils.js';
 import { filterFleetByAccess, ensureAccessibleLocation } from './access.js';
 
 export function populateLocationFilters() {
@@ -65,7 +65,7 @@ function filteredFleet() {
     .filter(truck => state.fleetFilter.location === 'Alle locaties' || truck.location === state.fleetFilter.location)
     .filter(truck => {
       if (!query) return true;
-      return [truck.id, truck.ref, truck.model]
+      return [truck.id, truck.ref, truck.model, truck.modelType, truck.contract?.nummer, truck.location]
         .map(value => (value == null ? '' : String(value)))
         .some(value => value.toLowerCase().includes(query));
     });
@@ -77,21 +77,29 @@ export function renderFleet() {
 
   const rows = filteredFleet().map(truck => {
     const activityList = Array.isArray(truck.activity) ? truck.activity : [];
-    const openCount = activityList.filter(activity => activity?.status === 'Open').length;
+    const openCount =
+      typeof truck.openActivityCount === 'number'
+        ? truck.openActivityCount
+        : activityList.filter(activity => activity?.status === 'Open').length;
     return `
       <tr class="border-b hover:bg-gray-50">
         <td class="py-3 px-3" data-label="Serienummer / Referentie">
           <button class="text-left text-gray-900 hover:underline" data-open-detail="${truck.id}">
             <div class="font-medium">${truck.id}</div>
             <div class="text-xs text-gray-500">${truck.ref}</div>
+            <div class="text-xs text-gray-400">${truck.fleetName || '—'}</div>
           </button>
         </td>
-        <td class="py-3 px-3" data-label="Vloot">${truck.fleetName || '—'}</td>
+        <td class="py-3 px-3" data-label="Modeltype">${truck.modelType || '—'}</td>
         <td class="py-3 px-3" data-label="Model">${truck.model}</td>
         <td class="py-3 px-3" data-label="BMWT‑status">${truck.bmwStatus}</td>
         <td class="py-3 px-3" data-label="BMWT‑vervaldatum">${fmtDate(truck.bmwExpiry)}</td>
-        <td class="py-3 px-3" data-label="Tellerstand (datum)">${formatOdoHtml(truck.odo, truck.odoDate)}</td>
-        <td class="py-3 px-3" data-label="Activiteit">
+        <td class="py-3 px-3" data-label="Locatie">${truck.location || '—'}</td>
+        <td class="py-3 px-3" data-label="Urenstand (datum)">${formatHoursHtml(truck.hours, truck.hoursDate)}</td>
+        <td class="py-3 px-3" data-label="Contractnummer">${truck.contract?.nummer || '—'}</td>
+        <td class="py-3 px-3" data-label="Contract startdatum">${fmtDate(truck.contract?.start)}</td>
+        <td class="py-3 px-3" data-label="Contract einddatum">${fmtDate(truck.contract?.eind)}</td>
+        <td class="py-3 px-3" data-label="Openstaande meldingen">
           <button class="inline-flex items-center justify-center w-7 h-7 bg-red-100 text-motrac-red rounded-full font-semibold" title="Open meldingen" data-open-detail="${truck.id}">${openCount}</button>
         </td>
         <td class="py-3 px-3 sm:text-right" data-label="Acties">
@@ -99,7 +107,7 @@ export function renderFleet() {
             <button class="px-2 py-1 border rounded-lg">⋮</button>
             <div class="kebab-menu hidden absolute right-0 mt-2 w-56 bg-white border rounded-lg shadow-soft z-10">
               <button class="w-full text-left px-4 py-2 hover:bg-gray-50" data-action="newTicket" data-id="${truck.id}">Melding aanmaken</button>
-              <button class="w-full text-left px-4 py-2 hover:bg-gray-50" data-action="updateOdo" data-id="${truck.id}">Tellerstand doorgeven</button>
+              <button class="w-full text-left px-4 py-2 hover:bg-gray-50" data-action="updateOdo" data-id="${truck.id}">Urenstand doorgeven</button>
               <button class="w-full text-left px-4 py-2 hover:bg-gray-50" data-action="editRef" data-id="${truck.id}">Uw referentie wijzigen</button>
               <button class="w-full text-left px-4 py-2 hover:bg-gray-50" data-action="showContract" data-id="${truck.id}">Contract inzien</button>
               <button class="w-full text-left px-4 py-2 hover:bg-gray-50 text-red-600" data-action="inactive" data-id="${truck.id}">Verwijderen uit lijst</button>
@@ -110,5 +118,5 @@ export function renderFleet() {
   }).join('');
 
   tableBody.innerHTML =
-    rows || '<tr><td colspan="8" class="py-6 px-3 text-center text-gray-500">Geen resultaten</td></tr>';
+    rows || '<tr><td colspan="12" class="py-6 px-3 text-center text-gray-500">Geen resultaten</td></tr>';
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,7 @@ export const fmtDate = iso => {
   return Number.isNaN(date.valueOf()) ? '—' : date.toLocaleDateString('nl-NL');
 };
 
-export const formatOdoValue = value => {
+const formatNumericValue = value => {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value.toLocaleString('nl-NL');
   }
@@ -20,8 +20,8 @@ export const formatOdoValue = value => {
   return '—';
 };
 
-export const formatOdoHtml = (value, date) => {
-  const odo = formatOdoValue(value);
+const formatNumericHtml = (value, date) => {
+  const odo = formatNumericValue(value);
   const formattedDate = fmtDate(date);
   if (formattedDate === '—') {
     return odo;
@@ -29,11 +29,19 @@ export const formatOdoHtml = (value, date) => {
   return `${odo} <span class="text-xs text-gray-500">(${formattedDate})</span>`;
 };
 
-export const formatOdoLabel = (value, date) => {
-  const odo = formatOdoValue(value);
+const formatNumericLabel = (value, date) => {
+  const odo = formatNumericValue(value);
   const formattedDate = fmtDate(date);
   return formattedDate === '—' ? odo : `${odo} (${formattedDate})`;
 };
+
+export const formatHoursValue = formatNumericValue;
+export const formatHoursHtml = formatNumericHtml;
+export const formatHoursLabel = formatNumericLabel;
+
+export const formatOdoValue = formatNumericValue;
+export const formatOdoHtml = formatNumericHtml;
+export const formatOdoLabel = formatNumericLabel;
 
 export function showToast(message) {
   const toast = $('#toast');


### PR DESCRIPTION
## Summary
- extend the fleet overview table with model type, location, usage hours, contract details, and open ticket counts
- normalise fleet data structures and Supabase fetch logic to expose the new attributes consistently across the app
- update the Supabase schema and overview view to store model type, hours readings, and open activity counts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed61961bf8832bacde90935805080f