### PR TITLE
Fix Supabase client to rely on session token

### DIFF
--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -47,13 +47,9 @@ function createNoCacheFetch() {
 const { url: SUPABASE_URL, anonKey: SUPABASE_ANON_KEY } = resolveSupabaseConfig();
 
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-  auth: {
-    persistSession: false
-  },
   global: {
     headers: {
       apikey: SUPABASE_ANON_KEY,
-      Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
       'Cache-Control': 'no-store',
       Pragma: 'no-cache',
       Expires: '0'


### PR DESCRIPTION
## Summary
- remove the hardcoded Authorization header so Supabase can send the authenticated session token
- rely on the default session persistence while keeping the existing cache-control configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee63635acc832b80e6fc40e4042544