### PR TITLE
Refactor portal to use local data store and simplify login

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,11 +63,11 @@
       </div>
       <form id="loginForm" class="space-y-5">
         <div>
-          <label for="loginEmail" class="block text-sm font-medium text-gray-700">E-mailadres</label>
+          <label for="loginEmail" class="block text-sm font-medium text-gray-700">Inlognaam</label>
           <input
             id="loginEmail"
-            type="email"
-            autocomplete="email"
+            type="text"
+            autocomplete="username"
             required
             class="mt-1 w-full border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-motrac-red focus:border-transparent"
           />


### PR DESCRIPTION
## Summary
- replace the Supabase client with an in-app data store and stubbed auth that accepts the test/test credentials
- seed account requests and portal data locally so the app no longer depends on Supabase
- update the login form to accept a generic username instead of requiring an email address

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f0d6903c6c832b9644eab8e96e0fe9