### PR TITLE
Prefill login credentials on login form

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
             id="loginEmail"
             type="text"
             autocomplete="username"
+            value="test@motrac.nl"
             required
             class="mt-1 w-full border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-motrac-red focus:border-transparent"
           />
@@ -78,6 +79,7 @@
             id="loginPassword"
             type="password"
             autocomplete="current-password"
+            value="test"
             required
             class="mt-1 w-full border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-motrac-red focus:border-transparent"
           />

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -20,6 +20,9 @@ import { renderUsers } from './users.js';
 import { applyEnvironmentForRole } from './tabs.js';
 import { setMainTab } from './navigation.js';
 
+const DEFAULT_LOGIN_EMAIL = 'test@motrac.nl';
+const DEFAULT_LOGIN_PASSWORD = 'test';
+
 function setLoginStatus(message = '') {
   const statusEl = $('#loginStatus');
   if (!statusEl) return;
@@ -58,11 +61,12 @@ export function showLoginPage() {
   setLoginFormDisabled(false);
   const emailInput = $('#loginEmail');
   if (emailInput) {
+    emailInput.value = DEFAULT_LOGIN_EMAIL;
     emailInput.focus();
   }
   const passwordInput = $('#loginPassword');
   if (passwordInput) {
-    passwordInput.value = '';
+    passwordInput.value = DEFAULT_LOGIN_PASSWORD;
   }
 }
 


### PR DESCRIPTION
## Summary
- preset the login form with the default test account details
- restore the default credentials whenever the login page is shown again

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f22a90f40c832bb64f8f641102a95e