### PR TITLE
Handle missing desktop new ticket button

### DIFF
--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -208,7 +208,7 @@ export function wireEvents() {
     if (event.key === 'Escape') closeModals();
   });
 
-  $('#btnNewTicket').addEventListener('click', () => openModal('#modalTicket'));
+  $('#btnNewTicket')?.addEventListener('click', () => openModal('#modalTicket'));
   $('#btnNewTicketMobile')?.addEventListener('click', () => {
     openModal('#modalTicket');
     collapseMobileMenu();


### PR DESCRIPTION
## Summary
- guard the desktop "new ticket" button listener behind optional chaining so event wiring no longer throws when the button is absent

## Testing
- Manual verification by removing the desktop button markup confirmed login still proceeds and the rest of the UI remains functional

------
https://chatgpt.com/codex/tasks/task_e_68f2305de808832bb8c4e29d483a1005