### PR TITLE
Restore modular frontend architecture

### DIFF
--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -208,7 +208,7 @@ export function wireEvents() {
     if (event.key === 'Escape') closeModals();
   });
 
-  $('#btnNewTicket').addEventListener('click', () => openModal('#modalTicket'));
+  $('#btnNewTicket')?.addEventListener('click', () => openModal('#modalTicket'));
   $('#btnNewTicketMobile')?.addEventListener('click', () => {
     openModal('#modalTicket');
     collapseMobileMenu();


### PR DESCRIPTION
## Summary
- restore the modular frontend implementation, including the Supabase mock API, data definitions, shared state, and UI modules
- reinstate the DOMContentLoaded bootstrap that wires UI events and initializes authentication
- guard the desktop new-ticket button binding so missing markup no longer prevents event wiring or auth startup

## Testing
- `node --check src/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68f2305de808832bb8c4e29d483a1005