### PR TITLE
Fix login syntax error that blocked login form

### DIFF
--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -243,9 +243,18 @@ export function wireEvents() {
     switchMainTab('activiteit');
     showToast('Servicemelding aangemaakt.');
 
-    $('#ticketOrder')?.value = '';
-    $('#ticketDesc')?.value = '';
-    $('#ticketPhotos')?.value = '';
+    const orderInput = $('#ticketOrder');
+    if (orderInput) {
+      orderInput.value = '';
+    }
+    const ticketDesc = $('#ticketDesc');
+    if (ticketDesc) {
+      ticketDesc.value = '';
+    }
+    const ticketPhotos = $('#ticketPhotos');
+    if (ticketPhotos) {
+      ticketPhotos.value = '';
+    }
   });
 
   $('#odoSave')?.addEventListener('click', event => {


### PR DESCRIPTION
## Summary
- replace invalid optional chaining assignments when clearing ticket form inputs
- resolve runtime syntax error so login flow and other scripts execute again

## Testing
- node --check src/modules/events.js

------
https://chatgpt.com/codex/tasks/task_e_68f245cc02f8832b813ef3d1f49da3ef