### PR TITLE
Add floating theme toggle button

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,20 @@
     }
   </script>
   <link rel="stylesheet" href="styles.css" />
+  <script>
+    (() => {
+      try {
+        const storageKey = 'motrac-theme';
+        const storedTheme = localStorage.getItem(storageKey);
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (storedTheme === 'dark' || (!storedTheme && prefersDark)) {
+          document.documentElement.setAttribute('data-theme', 'dark');
+        }
+      } catch (error) {
+        console.error('Thema kan niet vooraf worden ingesteld:', error);
+      }
+    })();
+  </script>
 </head>
 <body class="bg-motrac-gray text-gray-900">
   <!-- Login Page -->
@@ -577,6 +591,11 @@
 
   <!-- Toast -->
   <div id="toast" class="fixed bottom-4 left-1/2 -translate-x-1/2 hidden bg-gray-900 text-white px-4 py-2 rounded-lg shadow-soft"></div>
+
+  <button id="themeToggle" class="theme-toggle" type="button" aria-label="Schakel naar donker thema">
+    <span class="theme-toggle__icon" aria-hidden="true">🌞</span>
+    <span class="theme-toggle__label">Donker thema</span>
+  </button>
 
   <script type="module" src="src/main.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,9 @@
 import { wireEvents } from './modules/events.js';
 import { initializeAuth } from './modules/auth.js';
+import { initThemeToggle } from './modules/theme.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   wireEvents();
   await initializeAuth();
+  initThemeToggle();
 });

--- a/src/modules/theme.js
+++ b/src/modules/theme.js
@@ -1,0 +1,81 @@
+const STORAGE_KEY = 'motrac-theme';
+const DARK = 'dark';
+const LIGHT = 'light';
+
+function applyTheme(theme) {
+  const root = document.documentElement;
+  if (theme === DARK) {
+    root.setAttribute('data-theme', DARK);
+  } else {
+    root.removeAttribute('data-theme');
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, theme);
+  } catch (error) {
+    console.error('Thema kon niet opgeslagen worden:', error);
+  }
+  updateToggle(theme);
+}
+
+function getActiveTheme() {
+  return document.documentElement.getAttribute('data-theme') === DARK ? DARK : LIGHT;
+}
+
+function updateToggle(activeTheme) {
+  const toggle = document.getElementById('themeToggle');
+  if (!toggle) return;
+
+  const icon = toggle.querySelector('.theme-toggle__icon');
+  const label = toggle.querySelector('.theme-toggle__label');
+
+  const nextTheme = activeTheme === DARK ? LIGHT : DARK;
+  const isNextDark = nextTheme === DARK;
+
+  if (icon) {
+    icon.textContent = isNextDark ? '🌞' : '🌙';
+  }
+  if (label) {
+    label.textContent = isNextDark ? 'Donker thema' : 'Licht thema';
+  }
+
+  const ariaLabel = `Schakel naar ${isNextDark ? 'donker' : 'licht'} thema`;
+  toggle.setAttribute('aria-label', ariaLabel);
+}
+
+export function initThemeToggle() {
+  const toggle = document.getElementById('themeToggle');
+  if (!toggle) return;
+
+  const storedTheme = (() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch (error) {
+      console.error('Thema kon niet uit opslag worden gelezen:', error);
+      return null;
+    }
+  })();
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+  const defaultTheme = prefersDark.matches ? DARK : LIGHT;
+  const initialTheme = storedTheme === DARK || storedTheme === LIGHT ? storedTheme : defaultTheme;
+
+  applyTheme(initialTheme);
+
+  toggle.addEventListener('click', () => {
+    const nextTheme = getActiveTheme() === DARK ? LIGHT : DARK;
+    applyTheme(nextTheme);
+  });
+
+  prefersDark.addEventListener?.('change', event => {
+    const stored = (() => {
+      try {
+        return localStorage.getItem(STORAGE_KEY);
+      } catch (error) {
+        console.error('Thema kon niet uit opslag worden gelezen:', error);
+        return null;
+      }
+    })();
+    if (stored !== DARK && stored !== LIGHT) {
+      applyTheme(event.matches ? DARK : LIGHT);
+    }
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -297,6 +297,46 @@ h4 {
   white-space: nowrap;
 }
 
+:root[data-theme="dark"] body {
+  background: var(--color-background) !important;
+  color: var(--color-text) !important;
+}
+
+:root[data-theme="dark"] .bg-white,
+:root[data-theme="dark"] .bg-gray-50,
+:root[data-theme="dark"] .bg-gray-100,
+:root[data-theme="dark"] .bg-motrac-gray,
+:root[data-theme="dark"] .bg-slate-50 {
+  background-color: var(--color-surface) !important;
+  color: var(--color-text) !important;
+}
+
+:root[data-theme="dark"] .text-gray-900,
+:root[data-theme="dark"] .text-gray-800,
+:root[data-theme="dark"] .text-gray-700 {
+  color: var(--color-text) !important;
+}
+
+:root[data-theme="dark"] .text-gray-600,
+:root[data-theme="dark"] .text-gray-500,
+:root[data-theme="dark"] .text-gray-400,
+:root[data-theme="dark"] .text-gray-300 {
+  color: var(--color-muted) !important;
+}
+
+:root[data-theme="dark"] .border-gray-100,
+:root[data-theme="dark"] .border-gray-200,
+:root[data-theme="dark"] .border-gray-300,
+:root[data-theme="dark"] .border-gray-400,
+:root[data-theme="dark"] .border-gray-700,
+:root[data-theme="dark"] .border-motrac-gray {
+  border-color: var(--color-border) !important;
+}
+
+:root[data-theme="dark"] .shadow-soft {
+  box-shadow: var(--shadow-md) !important;
+}
+
 @media (max-width: 600px) {
   .theme-toggle {
     right: 16px;


### PR DESCRIPTION
## Summary
- add a floating theme toggle button to switch between light and dark display modes
- persist the selected theme and update UI colors to match the active theme

## Testing
- Manually tested in browser

------
https://chatgpt.com/codex/tasks/task_e_68f24ec974c4832b896c65431a8ceaa5