### PR TITLE
Replace portal logo with official Motrac artwork

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,23 +52,11 @@
     <div class="w-full max-w-md bg-white rounded-xl shadow-soft p-8 space-y-6">
       <div class="flex items-center gap-3">
         <div class="w-10 h-10 bg-motrac-red rounded-lg flex items-center justify-center">
-          <svg
-            class="w-7 h-7 text-white"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.6"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <circle cx="7.5" cy="17.5" r="2.5" />
-            <circle cx="16.5" cy="17.5" r="2.5" />
-            <path d="M4 17.5V14a3 3 0 0 1 3-3h4.5l2 4h3.5" />
-            <path d="M3 17.5h18" />
-            <path d="M14.5 6.5h2l2 6v5" />
-            <path d="M8.5 6.5v4.5" />
-          </svg>
+          <img
+            src="./LMH_MOTRAC_LOGO_1_RGB_Social.ai"
+            alt="Motrac logo"
+            class="w-7 h-7 object-contain"
+          />
         </div>
         <div>
           <h1 class="text-xl font-semibold">Motrac Serviceportal</h1>
@@ -127,23 +115,11 @@
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
         <div class="flex items-center gap-3 order-1 sm:order-1">
           <div class="w-9 h-9 bg-motrac-red rounded-lg flex items-center justify-center">
-            <svg
-              class="w-6 h-6 text-white"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.6"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              aria-hidden="true"
-            >
-              <circle cx="7.5" cy="17.5" r="2.5" />
-              <circle cx="16.5" cy="17.5" r="2.5" />
-              <path d="M4 17.5V14a3 3 0 0 1 3-3h4.5l2 4h3.5" />
-              <path d="M3 17.5h18" />
-              <path d="M14.5 6.5h2l2 6v5" />
-              <path d="M8.5 6.5v4.5" />
-            </svg>
+            <img
+              src="./LMH_MOTRAC_LOGO_1_RGB_Social.ai"
+              alt="Motrac logo"
+              class="w-6 h-6 object-contain"
+            />
           </div>
           <div class="leading-tight">
             <h1 class="font-semibold">Motrac Serviceportal</h1>


### PR DESCRIPTION
## Summary
- replace the placeholder forklift SVG in the login header with the official Motrac logo asset
- update the main navigation logo to reuse the same official artwork

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68f257070f6c832bb4a2a408004eaffe