### PR TITLE
Switch to official Motrac logo asset

### DIFF
--- a/assets/motrac-logo.svg
+++ b/assets/motrac-logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title>Motrac logo</title>
+  <desc>Gestileerde letter M in wit op een rood vlak met afgeronde hoeken.</desc>
+  <rect x="2" y="2" width="60" height="60" rx="10" ry="10" fill="#E30613" />
+  <path d="M16 44V20h8l8 12 8-12h8v24h-6V29.5l-10 14.5-10-14.5V44z" fill="#ffffff" />
+  <rect x="10" y="10" width="44" height="44" rx="8" ry="8" fill="none" stroke="#ffffff" stroke-width="2" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -51,13 +51,13 @@
   <div id="loginPage" class="min-h-screen flex items-center justify-center px-4 py-10">
     <div class="w-full max-w-md bg-white rounded-xl shadow-soft p-8 space-y-6">
       <div class="flex items-center gap-3">
-        <div class="w-10 h-10 bg-motrac-red rounded-lg flex items-center justify-center">
-          <img
-            src="./LMH_MOTRAC_LOGO_1_RGB_Social.ai"
-            alt="Motrac logo"
-            class="w-7 h-7 object-contain"
-          />
-        </div>
+        <object
+          data="./LMH_MOTRAC_LOGO_1_RGB_Social.ai"
+          type="application/pdf"
+          role="img"
+          aria-label="Motrac logo"
+          class="h-10 w-auto"
+        >Motrac</object>
         <div>
           <h1 class="text-xl font-semibold">Motrac Serviceportal</h1>
           <p class="text-sm text-gray-500">Log in met uw account</p>
@@ -114,13 +114,13 @@
     <header class="bg-white shadow-soft sticky top-0 z-40">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
         <div class="flex items-center gap-3 order-1 sm:order-1">
-          <div class="w-9 h-9 bg-motrac-red rounded-lg flex items-center justify-center">
-            <img
-              src="./LMH_MOTRAC_LOGO_1_RGB_Social.ai"
-              alt="Motrac logo"
-              class="w-6 h-6 object-contain"
-            />
-          </div>
+          <object
+            data="./LMH_MOTRAC_LOGO_1_RGB_Social.ai"
+            type="application/pdf"
+            role="img"
+            aria-label="Motrac logo"
+            class="h-9 w-auto"
+          >Motrac</object>
           <div class="leading-tight">
             <h1 class="font-semibold">Motrac Serviceportal</h1>
             <p class="text-xs text-gray-500">Prototype • geen echte data</p>


### PR DESCRIPTION
## Summary
- embed the official LMH_MOTRAC_LOGO_1_RGB_Social Illustrator asset for the login and application headers
- include fallback text inside the object tags so the Motrac name is still announced if the vector cannot render

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2a9d74eb4832bbe9fc88bf1b7b64f