### PR TITLE
Fix logo sizing regression

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,13 +51,11 @@
   <div id="loginPage" class="min-h-screen flex items-center justify-center px-4 py-10">
     <div class="w-full max-w-md bg-white rounded-xl shadow-soft p-8 space-y-6">
       <div class="flex items-center gap-3">
-        <object
-          data="./LMH_MOTRAC_LOGO_1_RGB_Social.ai"
-          type="application/pdf"
-          role="img"
-          aria-label="Motrac logo"
-          class="h-10 w-auto"
-        >Motrac</object>
+        <img
+          src="./assets/motrac-logo.svg"
+          alt="Motrac logo"
+          class="logo"
+        />
         <div>
           <h1 class="text-xl font-semibold">Motrac Serviceportal</h1>
           <p class="text-sm text-gray-500">Log in met uw account</p>
@@ -114,13 +112,11 @@
     <header class="bg-white shadow-soft sticky top-0 z-40">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
         <div class="flex items-center gap-3 order-1 sm:order-1">
-          <object
-            data="./LMH_MOTRAC_LOGO_1_RGB_Social.ai"
-            type="application/pdf"
-            role="img"
-            aria-label="Motrac logo"
-            class="h-9 w-auto"
-          >Motrac</object>
+          <img
+            src="./assets/motrac-logo.svg"
+            alt="Motrac logo"
+            class="logo"
+          />
           <div class="leading-tight">
             <h1 class="font-semibold">Motrac Serviceportal</h1>
             <p class="text-xs text-gray-500">Prototype • geen echte data</p>

--- a/styles.css
+++ b/styles.css
@@ -159,6 +159,12 @@ h4 {
   transition: background-color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease, color 0.25s ease;
 }
 
+.logo {
+  height: 40px;
+  width: auto;
+  display: block;
+}
+
 .sub {
   color: var(--color-muted);
 }


### PR DESCRIPTION
## Summary
- replace the Adobe Illustrator object embed of the Motrac logo with the SVG asset so sizing is respected across browsers
- add a shared `.logo` style to enforce the intended height and preserve aspect ratio for each logo placement

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f2ae91aa50832bae8835cbe1693e9f