### PR TITLE
Show environment info inline in header

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,6 +153,20 @@
           >
             <span>Servicemelding maken</span>
           </button>
+          <div
+            id="environmentInline"
+            class="flex flex-col sm:flex-row sm:items-center sm:gap-2 px-3 py-2 bg-gray-100 rounded-lg text-xs text-gray-500"
+          >
+            <span class="uppercase tracking-wide text-[10px] text-gray-400 sm:hidden">Omgeving</span>
+            <div class="flex items-center gap-2">
+              <span class="hidden sm:inline uppercase tracking-wide text-[10px] text-gray-400">Omgeving</span>
+              <span id="environmentInlineLabel" class="text-sm font-medium text-gray-700">Beheerder</span>
+              <span class="hidden sm:inline text-gray-300">•</span>
+              <span id="environmentInlineSummary" class="hidden sm:inline text-xs text-gray-500">
+                Volledige toegang tot vloot, activiteiten en gebruikersbeheer.
+              </span>
+            </div>
+          </div>
           <button
             id="mobileMenuToggle"
             class="sm:hidden inline-flex items-center gap-2 px-3 py-2 border rounded-lg text-sm"
@@ -186,27 +200,6 @@
 
     <!-- Content -->
     <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-4">
-      <section
-        id="environmentNotice"
-        class="bg-white rounded-xl shadow-soft p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"
-      >
-        <div>
-          <p class="text-xs uppercase tracking-wide text-gray-500">Huidige omgeving</p>
-          <h2 id="environmentName" class="text-base font-semibold">Beheerder</h2>
-        </div>
-        <div class="sm:text-right">
-          <span
-            id="environmentBadge"
-            class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-semibold bg-motrac-red text-white"
-          >
-            Beheerder
-          </span>
-          <p id="environmentSummary" class="text-sm text-gray-600 sm:max-w-md">
-            Volledige toegang tot vloot, activiteiten en gebruikersbeheer.
-          </p>
-        </div>
-      </section>
-
       <!-- VLOOT -->
       <section id="tab-vloot" class="space-y-4">
         <!-- Filters -->

--- a/src/modules/tabs.js
+++ b/src/modules/tabs.js
@@ -40,19 +40,14 @@ export function applyEnvironmentForRole(role) {
   state.activeEnvironmentKey = environment.key;
   state.allowedTabs = [...environment.allowedTabs];
 
-  const nameEl = $('#environmentName');
-  if (nameEl) {
-    nameEl.textContent = environment.label;
+  const inlineLabelEl = $('#environmentInlineLabel');
+  if (inlineLabelEl) {
+    inlineLabelEl.textContent = environment.label;
   }
 
-  const badgeEl = $('#environmentBadge');
-  if (badgeEl) {
-    badgeEl.textContent = environment.label;
-  }
-
-  const summaryEl = $('#environmentSummary');
-  if (summaryEl) {
-    summaryEl.textContent = environment.summary;
+  const inlineSummaryEl = $('#environmentInlineSummary');
+  if (inlineSummaryEl) {
+    inlineSummaryEl.textContent = environment.summary;
   }
 
   $$('#mainTabs button').forEach(button => {


### PR DESCRIPTION
## Summary
- remove the environment notice card from the main content
- display the active environment label and summary inline next to the user menu
- update the environment switching logic to populate the new inline display

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68f2b27d6a14832bac8f6b70374c7345