### PR TITLE
Handle missing DOM nodes during auth state resets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "motrac-service-portaal",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test tests"
+  }
+}

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -260,7 +260,10 @@ function resetState() {
   state.activeEnvironmentKey = 'pending';
   state.activeTab = null;
   setMainTab(null);
-  $('#currentUserName').textContent = 'Niet ingelogd';
+  const currentUserName = $('#currentUserName');
+  if (currentUserName) {
+    currentUserName.textContent = 'Niet ingelogd';
+  }
   const userMenuName = $('#userMenuName');
   if (userMenuName) {
     userMenuName.textContent = 'Niet ingelogd';
@@ -322,7 +325,10 @@ export async function handleAuthenticatedSession(session, { forceReload = false 
 
   const displayName =
     mergedProfile?.display_name || session.user.user_metadata?.full_name || session.user.email || 'Ingelogde gebruiker';
-  $('#currentUserName').textContent = displayName;
+  const currentUserName = $('#currentUserName');
+  if (currentUserName) {
+    currentUserName.textContent = displayName;
+  }
   const userMenuName = $('#userMenuName');
   if (userMenuName) {
     userMenuName.textContent = displayName;

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+function createStubElement() {
+  return {
+    classList: {
+      add() {},
+      remove() {},
+      toggle() {},
+      contains() {
+        return false;
+      }
+    },
+    setAttribute() {},
+    removeAttribute() {},
+    appendChild() {},
+    append() {},
+    querySelector() {
+      return null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+    addEventListener() {},
+    removeEventListener() {},
+    focus() {},
+    textContent: '',
+    innerHTML: '',
+    value: ''
+  };
+}
+
+const elementCache = new Map();
+
+function getOrCreateElement(selector) {
+  if (!elementCache.has(selector)) {
+    elementCache.set(selector, createStubElement());
+  }
+  return elementCache.get(selector);
+}
+
+function querySelector(selector) {
+  if (selector === '#currentUserName') {
+    return null;
+  }
+  return getOrCreateElement(selector);
+}
+
+global.document = {
+  querySelector,
+  querySelectorAll() {
+    return [];
+  },
+  getElementById: querySelector,
+  createElement() {
+    return createStubElement();
+  },
+  createTextNode(value) {
+    return { textContent: String(value ?? '') };
+  },
+  body: {
+    appendChild() {},
+    removeChild() {}
+  }
+};
+
+global.window = {
+  matchMedia() {
+    return {
+      matches: false,
+      addEventListener() {},
+      removeEventListener() {},
+      addListener() {},
+      removeListener() {}
+    };
+  },
+  sessionStorage: {
+    getItem() {
+      return null;
+    },
+    setItem() {},
+    removeItem() {}
+  },
+  localStorage: {
+    getItem() {
+      return null;
+    },
+    setItem() {},
+    removeItem() {}
+  },
+  addEventListener() {},
+  removeEventListener() {},
+  setTimeout,
+  clearTimeout
+};
+
+global.localStorage = window.localStorage;
+global.sessionStorage = window.sessionStorage;
+
+globalThis.Element = function () {};
+
+delete global.navigator;
+
+global.navigator = {
+  userAgent: 'node'
+};
+
+const { handleAuthenticatedSession } = await import('../src/modules/auth.js');
+import { state } from '../src/state.js';
+
+test('handleAuthenticatedSession resets state safely when user name element is absent', async () => {
+  state.session = { access_token: 'token' };
+  state.profile = { role: 'Beheerder' };
+  await assert.doesNotReject(() => handleAuthenticatedSession(null, { forceReload: true }));
+  assert.equal(state.session, null);
+  assert.equal(state.profile, null);
+});


### PR DESCRIPTION
## Summary
- guard the auth state reset flow so it no longer assumes the current user label exists
- add a node:test suite covering the regression around missing user name elements
- add a minimal package.json with a script for running the automated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f2c0ad4280832bbbe388abb6b17635