### PR TITLE
Handle invalid sessions without user details

### DIFF
--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -285,8 +285,16 @@ function resetState() {
  * Applies persona information and loads data when the session changes.
  */
 export async function handleAuthenticatedSession(session, { forceReload = false } = {}) {
-  const currentToken = state.session?.access_token ?? null;
   const nextToken = session?.access_token ?? null;
+  const sessionUserId =
+    typeof session?.user?.id === 'string' ? session.user.id.trim() : '';
+
+  if (!session || !sessionUserId) {
+    resetState();
+    return;
+  }
+
+  const currentToken = state.session?.access_token ?? null;
 
   if ((!forceReload || state.hasLoadedInitialData) && currentToken === nextToken) {
     return;
@@ -294,19 +302,15 @@ export async function handleAuthenticatedSession(session, { forceReload = false 
 
   state.session = session;
 
-  if (!session) {
-    resetState();
-    return;
-  }
-
   setLoginStatus('Gegevens worden geladen…');
 
   let profile = state.profile;
-  const shouldFetchProfile = forceReload || !profile || profile?.auth_user_id !== session.user.id;
+  const shouldFetchProfile =
+    forceReload || !profile || profile?.auth_user_id !== sessionUserId;
 
   if (shouldFetchProfile) {
     try {
-      profile = await fetchProfileByAuthUserId(session.user.id);
+      profile = await fetchProfileByAuthUserId(sessionUserId);
     } catch (error) {
       console.error('Kon profielgegevens niet laden', error);
     }

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -115,3 +115,15 @@ test('handleAuthenticatedSession resets state safely when user name element is a
   assert.equal(state.session, null);
   assert.equal(state.profile, null);
 });
+
+test('handleAuthenticatedSession signs out gracefully when session user details are missing', async () => {
+  state.session = { access_token: 'token', user: { id: 'existing-user' } };
+  state.profile = { id: 'profile-id', auth_user_id: 'existing-user' };
+
+  const incompleteSession = { access_token: 'token', user: null };
+
+  await assert.doesNotReject(() => handleAuthenticatedSession(incompleteSession, { forceReload: true }));
+
+  assert.equal(state.session, null);
+  assert.equal(state.profile, null);
+});


### PR DESCRIPTION
## Summary
- prevent `handleAuthenticatedSession` from continuing when Supabase session metadata is missing user details
- keep state resets safe by trimming the session user id before fetching profile data
- add regression test covering missing session user information

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f2c9fc2000832b9d0a175f0f3b9341