### PR TITLE
Improve account lookup and environment resolution

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -42,11 +42,40 @@ export const ENVIRONMENTS = {
 
 export function getEnvironmentKeyForRole(role) {
   if (!role) return 'pending';
-  return ROLE_TO_ENVIRONMENT[role] || 'pending';
+  const value = typeof role === 'string' ? role.trim() : '';
+  if (!value) {
+    return 'pending';
+  }
+
+  const directMatch = ROLE_TO_ENVIRONMENT[value];
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const normalisedKey = Object.keys(ROLE_TO_ENVIRONMENT).find(
+    knownRole => knownRole.toLowerCase() === value.toLowerCase()
+  );
+
+  return normalisedKey ? ROLE_TO_ENVIRONMENT[normalisedKey] : 'pending';
 }
 
 export function resolveEnvironment(input) {
   if (!input) {
+    return ENVIRONMENTS.pending;
+  }
+
+  if (typeof input === 'object') {
+    if (input.key && ENVIRONMENTS[input.key]) {
+      return ENVIRONMENTS[input.key];
+    }
+
+    if (input.role) {
+      const keyFromRole = getEnvironmentKeyForRole(input.role);
+      if (ENVIRONMENTS[keyFromRole]) {
+        return ENVIRONMENTS[keyFromRole];
+      }
+    }
+
     return ENVIRONMENTS.pending;
   }
 

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -65,6 +65,10 @@ const TEST_ACCOUNTS = [
   }
 ];
 
+const ACCOUNT_LOOKUP = new Map(
+  TEST_ACCOUNTS.map(account => [normaliseEmail(account.email), account])
+);
+
 /**
  * Normalises e-mail input to ensure case-insensitive matching.
  */
@@ -77,7 +81,7 @@ function normaliseEmail(value) {
  */
 function findAccountByEmail(email) {
   const normalised = normaliseEmail(email);
-  return TEST_ACCOUNTS.find(account => normaliseEmail(account.email) === normalised) || null;
+  return ACCOUNT_LOOKUP.get(normalised) || null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- cache prototype account definitions by normalised email for faster lookups
- normalise environment resolution for varying role casing and allow passing environment objects safely

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f33cd02b00832bbe6df029be8bcb36