### PR TITLE
Add quick demo persona login options

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,6 +95,51 @@
           <span id="loginSubmitLoading" class="hidden">Bezig…</span>
         </button>
       </form>
+      <div class="space-y-3">
+        <p class="text-sm text-gray-500">Of kies een demo-account om direct in te loggen:</p>
+        <div class="grid gap-2 sm:grid-cols-2" role="list">
+          <button
+            type="button"
+            class="w-full rounded-lg border border-gray-200 px-4 py-3 text-left hover:border-motrac-red hover:text-motrac-red transition-colors"
+            data-persona-login
+            data-email="test@motrac.nl"
+            role="listitem"
+          >
+            <span class="block text-sm font-semibold">Beheerder</span>
+            <span class="block text-xs text-gray-500">Volledige toegang tot alle modules</span>
+          </button>
+          <button
+            type="button"
+            class="w-full rounded-lg border border-gray-200 px-4 py-3 text-left hover:border-motrac-red hover:text-motrac-red transition-colors"
+            data-persona-login
+            data-email="gebruiker@motrac.nl"
+            role="listitem"
+          >
+            <span class="block text-sm font-semibold">Gebruiker</span>
+            <span class="block text-xs text-gray-500">Standaard toegang tot vloot en activiteit</span>
+          </button>
+          <button
+            type="button"
+            class="w-full rounded-lg border border-gray-200 px-4 py-3 text-left hover:border-motrac-red hover:text-motrac-red transition-colors"
+            data-persona-login
+            data-email="vloot@motrac.nl"
+            role="listitem"
+          >
+            <span class="block text-sm font-semibold">Vlootbeheerder</span>
+            <span class="block text-xs text-gray-500">Toegang tot geselecteerde demovloot</span>
+          </button>
+          <button
+            type="button"
+            class="w-full rounded-lg border border-gray-200 px-4 py-3 text-left hover:border-motrac-red hover:text-motrac-red transition-colors"
+            data-persona-login
+            data-email="klant@motrac.nl"
+            role="listitem"
+          >
+            <span class="block text-sm font-semibold">Klant</span>
+            <span class="block text-xs text-gray-500">Inzicht in Van Dijk Logistics vloot</span>
+          </button>
+        </div>
+      </div>
       <p class="text-xs text-gray-400 text-center">Toegang uitsluitend voor geautoriseerde Motrac klanten.</p>
       <button
         type="button"

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -15,7 +15,7 @@ import { renderUsers, saveUser } from './users.js';
 import { openDetail, setDetailTab } from './detail.js';
 import { canViewFleetAsset } from './access.js';
 import { switchMainTab } from './tabs.js';
-import { handleLoginSubmit, signOut } from './auth.js';
+import { handleLoginSubmit, handlePersonaLogin, signOut } from './auth.js';
 import { handleAccountRequestSubmit, handleAccountRequestAction } from './accountRequests.js';
 
 export function wireEvents() {
@@ -67,6 +67,10 @@ export function wireEvents() {
   if (loginForm) {
     loginForm.addEventListener('submit', handleLoginSubmit);
   }
+
+  $$('[data-persona-login]').forEach(button =>
+    button.addEventListener('click', handlePersonaLogin)
+  );
 
   $$('#mainTabs button').forEach(button =>
     button.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add shortcut buttons on the login page for each demo persona to simplify prototype sign-in
- teach the browser storage API to create sessions for specific personas and align password login with them
- hook the new persona buttons into the auth flow and disable them during sign-in to avoid duplicate submissions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f33ea1caf0832bb2495163d769af68