### PR TITLE
Improve mobile navigation experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,10 +147,13 @@
             aria-label="Hoofdmenu"
           >
             <ul class="flex items-center justify-center gap-2 sm:gap-3 w-full" id="mainTabs">
-              <li>
+              <li data-tab-target="vloot">
                 <button
+                  type="button"
                   data-tab="vloot"
+                  data-nav-button
                   class="tab-active inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+                  aria-current="page"
                   aria-label="Vloot"
                   title="Vloot"
                 >
@@ -164,10 +167,13 @@
                   <span class="sr-only">Vloot</span>
                 </button>
               </li>
-              <li>
+              <li data-tab-target="activiteit">
                 <button
+                  type="button"
                   data-tab="activiteit"
+                  data-nav-button
                   class="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+                  aria-current="false"
                   aria-label="Activiteit"
                   title="Activiteit"
                 >
@@ -177,10 +183,13 @@
                   <span class="sr-only">Activiteit</span>
                 </button>
               </li>
-              <li>
+              <li data-tab-target="users">
                 <button
+                  type="button"
                   data-tab="users"
+                  data-nav-button
                   class="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+                  aria-current="false"
                   aria-label="Gebruikersbeheer"
                   title="Gebruikersbeheer"
                 >
@@ -230,7 +239,7 @@
     </header>
 
     <!-- Content -->
-    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-4">
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-28 sm:pb-8 space-y-4">
       <!-- VLOOT -->
       <section id="tab-vloot" class="space-y-4">
         <!-- Filters -->
@@ -380,6 +389,63 @@
         </div>
       </section>
     </main>
+    <nav
+      id="mobileTabBar"
+      class="mobile-tab-bar sm:hidden"
+      aria-label="Hoofdmenu"
+    >
+      <ul class="mobile-tab-bar__list">
+        <li class="mobile-tab-bar__item" data-tab-target="vloot">
+          <button
+            type="button"
+            data-tab="vloot"
+            data-nav-button
+            class="mobile-tab-bar__button tab-active"
+            aria-current="page"
+          >
+            <svg class="mobile-tab-bar__icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path
+                d="M4 6a2 2 0 012-2h8a2 2 0 012 2v5h2.586a1 1 0 01.707.293L21 14.414V17a1 1 0 01-1 1h-.382a2.25 2.25 0 11-4.486 0H9.868a2.25 2.25 0 11-4.486 0H5a1 1 0 01-1-1V6z"
+              />
+              <path d="M6.75 18a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" />
+              <path d="M16.75 18a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" />
+            </svg>
+            <span class="mobile-tab-bar__label">Vloot</span>
+          </button>
+        </li>
+        <li class="mobile-tab-bar__item" data-tab-target="activiteit">
+          <button
+            type="button"
+            data-tab="activiteit"
+            data-nav-button
+            class="mobile-tab-bar__button"
+            aria-current="false"
+          >
+            <svg class="mobile-tab-bar__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+              <path d="M4 13l3.5 3.5L13 7l3.5 5L20 9" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+            <span class="mobile-tab-bar__label">Activiteit</span>
+          </button>
+        </li>
+        <li class="mobile-tab-bar__item" data-tab-target="users">
+          <button
+            type="button"
+            data-tab="users"
+            data-nav-button
+            class="mobile-tab-bar__button"
+            aria-current="false"
+          >
+            <svg class="mobile-tab-bar__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+              <path d="M16 19v-1a3 3 0 00-3-3H7a3 3 0 00-3 3v1" stroke-linecap="round" stroke-linejoin="round" />
+              <circle cx="10" cy="8" r="3" />
+              <path d="M21 19v-1a3 3 0 00-2.4-2.94" stroke-linecap="round" stroke-linejoin="round" />
+              <path d="M15 4.14a3 3 0 010 5.72" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+            <span class="mobile-tab-bar__label">Gebruikers</span>
+          </button>
+        </li>
+      </ul>
+    </nav>
   </div>
 
   <!-- MODALS -->

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -72,7 +72,7 @@ export function wireEvents() {
     button.addEventListener('click', handlePersonaLogin)
   );
 
-  $$('#mainTabs button').forEach(button =>
+  $$('[data-nav-button]').forEach(button =>
     button.addEventListener('click', () => {
       if (button.disabled) return;
       switchMainTab(button.dataset.tab);

--- a/src/modules/navigation.js
+++ b/src/modules/navigation.js
@@ -1,8 +1,10 @@
 import { $, $$ } from '../utils.js';
 
 export function setMainTab(tab) {
-  $$('#mainTabs button').forEach(button => {
-    button.classList.toggle('tab-active', button.dataset.tab === tab);
+  $$('[data-nav-button]').forEach(button => {
+    const isActive = button.dataset.tab === tab;
+    button.classList.toggle('tab-active', isActive);
+    button.setAttribute('aria-current', isActive ? 'page' : 'false');
   });
   $('#tab-vloot').classList.toggle('hidden', tab !== 'vloot');
   $('#tab-activiteit').classList.toggle('hidden', tab !== 'activiteit');

--- a/src/modules/tabs.js
+++ b/src/modules/tabs.js
@@ -50,14 +50,15 @@ export function applyEnvironmentForRole(role) {
     inlineSummaryEl.textContent = environment.summary;
   }
 
-  $$('#mainTabs button').forEach(button => {
-    const allowed = environment.allowedTabs.includes(button.dataset.tab);
-    const listItem = button.closest('li');
-    if (listItem) {
-      listItem.classList.toggle('hidden', !allowed);
+  $$('[data-tab-target]').forEach(item => {
+    const tabKey = item.dataset.tabTarget;
+    const button = item.querySelector('[data-nav-button]');
+    const allowed = environment.allowedTabs.includes(tabKey);
+    item.classList.toggle('hidden', !allowed);
+    if (button) {
+      button.disabled = !allowed;
+      button.classList.toggle('opacity-40', !allowed);
     }
-    button.disabled = !allowed;
-    button.classList.toggle('opacity-40', !allowed);
   });
 
   switchMainTab(state.activeTab);

--- a/styles.css
+++ b/styles.css
@@ -200,6 +200,99 @@ h4 {
   transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.mobile-tab-bar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  padding: 0.35rem 1rem calc(0.75rem + env(safe-area-inset-bottom, 0));
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  box-shadow: 0 -12px 30px rgba(43, 43, 43, 0.14);
+  z-index: 45;
+  transition: background-color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.mobile-tab-bar__list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 420px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mobile-tab-bar__item {
+  display: flex;
+}
+
+.mobile-tab-bar__button {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-muted);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.mobile-tab-bar__button:active {
+  transform: translateY(1px);
+}
+
+.mobile-tab-bar__button:hover {
+  color: var(--color-text);
+}
+
+.mobile-tab-bar__button.tab-active {
+  background: rgba(227, 6, 19, 0.12);
+  border-color: rgba(227, 6, 19, 0.32);
+  color: var(--color-primary);
+  box-shadow: inset 0 0 0 1px rgba(227, 6, 19, 0.18);
+}
+
+.mobile-tab-bar__icon {
+  width: 1.35rem;
+  height: 1.35rem;
+}
+
+.mobile-tab-bar__label {
+  line-height: 1;
+}
+
+:root[data-theme="dark"] .mobile-tab-bar {
+  box-shadow: 0 -14px 36px rgba(0, 0, 0, 0.6);
+}
+
+:root[data-theme="dark"] .mobile-tab-bar__button {
+  color: var(--color-muted);
+}
+
+:root[data-theme="dark"] .mobile-tab-bar__button.tab-active {
+  background: rgba(227, 6, 19, 0.24);
+  border-color: rgba(227, 6, 19, 0.45);
+  color: var(--color-on-primary);
+  box-shadow: inset 0 0 0 1px rgba(227, 6, 19, 0.32);
+}
+
+@supports (padding: max(0px)) {
+  .mobile-tab-bar {
+    padding-bottom: calc(0.75rem + max(env(safe-area-inset-bottom, 0), 0px));
+  }
+}
+
 .main-nav a:hover,
 .main-nav a:focus-visible {
   color: var(--color-text);


### PR DESCRIPTION
## Summary
- add a persistent mobile tab bar to make the main areas reachable on phones
- sync navigation state and permissions across desktop and mobile controls
- refresh spacing and styling so content clears the new mobile navigation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f53ad66958832b8467d3a33895ebc5