### PR TITLE
Handle missing navigation tab elements

### DIFF
--- a/src/modules/navigation.js
+++ b/src/modules/navigation.js
@@ -6,8 +6,9 @@ export function setMainTab(tab) {
     button.classList.toggle('tab-active', isActive);
     button.setAttribute('aria-current', isActive ? 'page' : 'false');
   });
-  $('#tab-vloot').classList.toggle('hidden', tab !== 'vloot');
-  $('#tab-activiteit').classList.toggle('hidden', tab !== 'activiteit');
-  $('#tab-users').classList.toggle('hidden', tab !== 'users');
-  $('#truckDetail').classList.add('hidden');
+
+  $('#tab-vloot')?.classList.toggle('hidden', tab !== 'vloot');
+  $('#tab-activiteit')?.classList.toggle('hidden', tab !== 'activiteit');
+  $('#tab-users')?.classList.toggle('hidden', tab !== 'users');
+  $('#truckDetail')?.classList.add('hidden');
 }


### PR DESCRIPTION
## Summary
- guard navigation tab toggles against missing DOM nodes to avoid runtime errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f553e4d334832bbc57c0fe11d223cc