### PR TITLE
Simplify environment status banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,8 +116,8 @@
   <div id="app" class="min-h-screen hidden">
     <!-- Top Navigation -->
     <header class="bg-white shadow-soft sticky top-0 z-40">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div class="flex items-center gap-3 order-1">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex flex-wrap items-center gap-x-3 gap-y-2">
+        <div class="flex items-center gap-3 order-1 flex-shrink-0">
           <img
             src="./assets/motrac-logo.svg"
             alt="Motrac logo"
@@ -128,7 +128,7 @@
             <p class="text-xs text-gray-500">Prototype • geen echte data</p>
           </div>
         </div>
-        <div class="flex items-center gap-3 order-3 sm:order-2 sm:flex-1 sm:justify-center">
+        <div class="flex items-center gap-2 order-3 sm:order-2 sm:flex-1 sm:justify-center w-full sm:w-auto">
           <button
             id="mobileMenuToggle"
             class="sm:hidden inline-flex items-center justify-center w-10 h-10 rounded-lg border border-gray-200 text-gray-600"
@@ -205,19 +205,13 @@
             </ul>
           </nav>
         </div>
-        <div class="flex items-center gap-3 order-2 sm:order-3 sm:justify-end">
-          <div
-            id="environmentInline"
-            class="flex flex-col gap-1 text-xs sm:text-sm text-gray-600 leading-snug"
-          >
-            <span class="text-[11px] uppercase tracking-wide text-gray-400">Overzicht</span>
-            <p class="text-sm text-gray-700">
-              <span id="environmentInlineLabel" class="font-medium text-gray-800">Beheerder</span>
-              <span class="text-gray-400">–</span>
-              <span id="environmentInlineSummary" class="text-gray-600">
-                Volledige toegang tot vloot, activiteiten en gebruikersbeheer.
-              </span>
-            </p>
+        <div class="flex items-center gap-3 order-2 sm:order-3 sm:justify-end w-full sm:w-auto">
+          <div id="environmentInline" class="environment-pill" role="status" aria-live="polite">
+            <span class="environment-pill__dot" aria-hidden="true"></span>
+            <span id="environmentInlineLabel" class="environment-pill__role">Beheerder</span>
+            <span id="environmentInlineSummary" class="visually-hidden">
+              Volledige toegang tot vloot, activiteiten en gebruikersbeheer.
+            </span>
           </div>
           <div class="relative">
             <button

--- a/src/modules/tabs.js
+++ b/src/modules/tabs.js
@@ -50,6 +50,15 @@ export function applyEnvironmentForRole(role) {
     inlineSummaryEl.textContent = environment.summary;
   }
 
+  const inlineContainerEl = $('#environmentInline');
+  if (inlineContainerEl) {
+    inlineContainerEl.setAttribute('title', environment.summary);
+    inlineContainerEl.setAttribute(
+      'aria-label',
+      `${environment.label}. ${environment.summary}`
+    );
+  }
+
   $$('[data-tab-target]').forEach(item => {
     const tabKey = item.dataset.tabTarget;
     const button = item.querySelector('[data-nav-button]');

--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,35 @@
   border-radius: var(--radius-sm);
 }
 
+.environment-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  background: var(--color-subtle-surface);
+  border: 1px solid var(--color-highlight-border);
+  color: var(--color-muted);
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.environment-pill__dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 9999px;
+  background: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(176, 0, 32, 0.18);
+  flex-shrink: 0;
+}
+
+.environment-pill__role {
+  font-weight: 600;
+  color: var(--color-text);
+  font-size: 13px;
+  white-space: nowrap;
+}
+
 .user-status-indicator {
   width: 0.5rem;
   height: 0.5rem;


### PR DESCRIPTION
## Summary
- streamline the top navigation spacing so the banner renders as a compact strip
- replace the environment overview copy block with a minimalist status pill component
- add an accessible title/aria label so the full environment summary remains available without visual clutter

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f5648f9354832b8060f645e97d5be1