### PR TITLE
Remove obsolete mobile menu toggle button

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,18 +129,6 @@
           </div>
         </div>
         <div class="flex items-center gap-2 order-3 sm:order-2 sm:flex-1 sm:justify-center w-full sm:w-auto">
-          <button
-            id="mobileMenuToggle"
-            class="sm:hidden inline-flex items-center justify-center w-10 h-10 rounded-lg border border-gray-200 text-gray-600"
-            type="button"
-            aria-expanded="false"
-            aria-controls="mainNav"
-          >
-            <span class="sr-only">Menu</span>
-            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-              <path d="M4 7h16M4 12h16M4 17h16" stroke-linecap="round" />
-            </svg>
-          </button>
           <nav
             id="mainNav"
             class="hidden w-full sm:flex sm:w-auto sm:items-center sm:gap-4"

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -39,26 +39,10 @@ export function wireEvents() {
   }
 
   const mainNav = $('#mainNav');
-  const mobileMenuToggle = $('#mobileMenuToggle');
   const collapseMobileMenu = () => {
-    if (!mainNav || !mobileMenuToggle) return;
-    mainNav.classList.add('hidden');
-    mobileMenuToggle.setAttribute('aria-expanded', 'false');
-  };
-
-  mobileMenuToggle?.addEventListener('click', () => {
     if (!mainNav) return;
-    const isHidden = mainNav.classList.toggle('hidden');
-    mobileMenuToggle.setAttribute('aria-expanded', isHidden ? 'false' : 'true');
-  });
-
-  document.addEventListener('click', event => {
-    if (!mainNav || !mobileMenuToggle) return;
-    if (mainNav.classList.contains('hidden')) return;
-    if (!window.matchMedia('(max-width: 639px)').matches) return;
-    if (event.target.closest('#mainNav') || event.target.closest('#mobileMenuToggle')) return;
-    collapseMobileMenu();
-  });
+    mainNav.classList.add('hidden');
+  };
 
   const userBtn = $('#userBtn');
   const userMenu = $('#userMenu');


### PR DESCRIPTION
## Summary
- remove the mobile hamburger button from the header markup
- drop the unused event wiring for the removed toggle button

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f5691a4b50832b93be926e37221130