### PR TITLE
Improve navigation menu and hash routing between modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,72 +128,76 @@
             <p class="text-xs text-gray-500">Prototype • geen echte data</p>
           </div>
         </div>
-        <div class="flex items-center gap-2 order-3 sm:order-2 sm:flex-1 sm:justify-center w-full sm:w-auto">
+        <div class="flex items-center gap-4 order-3 sm:order-2 sm:flex-1 sm:justify-center w-full sm:w-auto">
           <nav
             id="mainNav"
-            class="hidden w-full sm:flex sm:w-auto sm:items-center sm:gap-4"
+            class="hidden w-full sm:flex sm:w-auto sm:items-center"
             aria-label="Hoofdmenu"
           >
-            <ul class="flex items-center justify-center gap-2 sm:gap-3 w-full" id="mainTabs">
-              <li data-tab-target="vloot">
+            <ul class="main-menu" id="mainTabs">
+              <li class="main-menu__item" data-tab-target="vloot">
                 <button
                   type="button"
                   data-tab="vloot"
                   data-nav-button
-                  class="tab-active inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+                  class="main-menu__button tab-active"
                   aria-current="page"
-                  aria-label="Vloot"
-                  title="Vloot"
                 >
-                  <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <svg class="main-menu__icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                     <path
                       d="M4 6a2 2 0 012-2h8a2 2 0 012 2v5h2.586a1 1 0 01.707.293L21 14.414V17a1 1 0 01-1 1h-.382a2.25 2.25 0 11-4.486 0H9.868a2.25 2.25 0 11-4.486 0H5a1 1 0 01-1-1V6z"
                     />
                     <path d="M6.75 18a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" />
                     <path d="M16.75 18a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" />
                   </svg>
-                  <span class="sr-only">Vloot</span>
+                  <span class="main-menu__label">Vloot</span>
                 </button>
               </li>
-              <li data-tab-target="activiteit">
+              <li class="main-menu__item" data-tab-target="activiteit">
                 <button
                   type="button"
                   data-tab="activiteit"
                   data-nav-button
-                  class="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+                  class="main-menu__button"
                   aria-current="false"
-                  aria-label="Activiteit"
-                  title="Activiteit"
                 >
-                  <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                  <svg class="main-menu__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                     <path d="M4 13l3.5 3.5L13 7l3.5 5L20 9" stroke-linecap="round" stroke-linejoin="round" />
                   </svg>
-                  <span class="sr-only">Activiteit</span>
+                  <span class="main-menu__label">Activiteit</span>
                 </button>
               </li>
-              <li data-tab-target="users">
+              <li class="main-menu__item" data-tab-target="users">
                 <button
                   type="button"
                   data-tab="users"
                   data-nav-button
-                  class="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+                  class="main-menu__button"
                   aria-current="false"
-                  aria-label="Gebruikersbeheer"
-                  title="Gebruikersbeheer"
                 >
-                  <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                  <svg class="main-menu__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                     <path d="M16 19v-1a3 3 0 00-3-3H7a3 3 0 00-3 3v1" stroke-linecap="round" stroke-linejoin="round" />
                     <circle cx="10" cy="8" r="3" />
                     <path d="M21 19v-1a3 3 0 00-2.4-2.94" stroke-linecap="round" stroke-linejoin="round" />
                     <path d="M15 4.14a3 3 0 010 5.72" stroke-linecap="round" stroke-linejoin="round" />
                   </svg>
-                  <span class="sr-only">Gebruikersbeheer</span>
+                  <span class="main-menu__label">Gebruikers</span>
                 </button>
               </li>
             </ul>
           </nav>
         </div>
         <div class="flex items-center gap-3 order-2 sm:order-3 sm:justify-end w-full sm:w-auto">
+          <button
+            id="moduleCycleBtn"
+            class="module-cycle hidden sm:inline-flex"
+            type="button"
+            aria-label="Volgende module"
+            title="Volgende module"
+          >
+            <span class="module-cycle__icon" aria-hidden="true">➜</span>
+            <span id="moduleCycleLabel" class="module-cycle__label">Volgende module</span>
+          </button>
           <div id="environmentInline" class="environment-pill" role="status" aria-live="polite">
             <span class="environment-pill__dot" aria-hidden="true"></span>
             <span id="environmentInlineLabel" class="environment-pill__role">Beheerder</span>

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -22,16 +22,11 @@ import { applyEnvironmentForRole } from './tabs.js';
 import { setMainTab } from './navigation.js';
 import { showToast } from './ui/toast.js';
 import { resolveEnvironment } from '../environment.js';
+import { TAB_LABELS } from './tabConfig.js';
 
 const DEFAULT_LOGIN_EMAIL = 'test@motrac.nl';
 const DEFAULT_LOGIN_PASSWORD = 'test';
 const LOCATION_STORAGE_KEY = 'motrac:lastLocation';
-const TAB_LABELS = {
-  vloot: 'Vloot',
-  activiteit: 'Activiteit',
-  users: 'Gebruikersbeheer'
-};
-
 const USER_STATUS_CLASSES = {
   active: 'user-status-indicator--active',
   pending: 'user-status-indicator--pending',

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -17,12 +17,14 @@ import { canViewFleetAsset } from './access.js';
 import { switchMainTab } from './tabs.js';
 import { handleLoginSubmit, handlePersonaLogin, signOut } from './auth.js';
 import { handleAccountRequestAction } from './accountRequests.js';
+import { initRouter } from './router.js';
 
 export function wireEvents() {
   if (state.eventsWired) return;
   state.eventsWired = true;
 
   initActivityComposer();
+  initRouter(switchMainTab);
 
   const getAccessibleTruck = truckId => {
     if (!truckId) return null;
@@ -484,4 +486,15 @@ export function wireEvents() {
   });
 
   $$('#truckDetail [data-subtab]').forEach(button => button.addEventListener('click', () => setDetailTab(button.dataset.subtab)));
+
+  $('#moduleCycleBtn')?.addEventListener('click', () => {
+    const allowedTabs = Array.isArray(state.allowedTabs) ? state.allowedTabs : [];
+    if (allowedTabs.length <= 1) return;
+    const currentIndex = allowedTabs.indexOf(state.activeTab);
+    const nextIndex = currentIndex >= 0 ? (currentIndex + 1) % allowedTabs.length : 0;
+    const nextTab = allowedTabs[nextIndex];
+    if (nextTab && nextTab !== state.activeTab) {
+      switchMainTab(nextTab);
+    }
+  });
 }

--- a/src/modules/navigation.js
+++ b/src/modules/navigation.js
@@ -1,4 +1,5 @@
 import { $, $$ } from '../utils.js';
+import { getTabLabel } from './tabConfig.js';
 
 export function setMainTab(tab) {
   $$('[data-nav-button]').forEach(button => {
@@ -11,4 +12,47 @@ export function setMainTab(tab) {
   $('#tab-activiteit')?.classList.toggle('hidden', tab !== 'activiteit');
   $('#tab-users')?.classList.toggle('hidden', tab !== 'users');
   $('#truckDetail')?.classList.add('hidden');
+}
+
+export function updateModuleCycleButton(allowedTabs, activeTab) {
+  const button = $('#moduleCycleBtn');
+  const label = $('#moduleCycleLabel');
+
+  if (!button || !label) return;
+
+  const availableTabs = Array.isArray(allowedTabs) ? allowedTabs.filter(Boolean) : [];
+
+  if (!availableTabs.length) {
+    const text = 'Geen modules beschikbaar';
+    button.disabled = true;
+    button.classList.add('module-cycle--disabled');
+    label.textContent = text;
+    button.setAttribute('aria-label', text);
+    button.setAttribute('title', text);
+    return;
+  }
+
+  if (availableTabs.length === 1) {
+    const text = `Enige module: ${getTabLabel(availableTabs[0])}`;
+    button.disabled = true;
+    button.classList.add('module-cycle--disabled');
+    label.textContent = text;
+    button.setAttribute('aria-label', text);
+    button.setAttribute('title', text);
+    return;
+  }
+
+  button.disabled = false;
+  button.classList.remove('module-cycle--disabled');
+
+  let currentIndex = availableTabs.indexOf(activeTab);
+  if (currentIndex < 0) {
+    currentIndex = -1;
+  }
+  const nextTab = availableTabs[(currentIndex + 1) % availableTabs.length];
+  const nextLabel = getTabLabel(nextTab);
+  const text = `Volgende: ${nextLabel}`;
+  label.textContent = text;
+  button.setAttribute('aria-label', `Ga naar ${nextLabel}`);
+  button.setAttribute('title', `Ga naar ${nextLabel}`);
 }

--- a/src/modules/router.js
+++ b/src/modules/router.js
@@ -1,0 +1,45 @@
+const HASH_PREFIX = '#/';
+let onRouteChange = null;
+let pendingHash = null;
+
+function normaliseHash(hash) {
+  if (typeof hash !== 'string') return null;
+  if (!hash.startsWith(HASH_PREFIX)) return null;
+  const value = hash.slice(HASH_PREFIX.length).trim();
+  return value || null;
+}
+
+function handleHashChange() {
+  if (pendingHash && window.location.hash === pendingHash) {
+    pendingHash = null;
+    return;
+  }
+
+  if (!onRouteChange) return;
+  const tab = getCurrentRoute();
+  if (tab) {
+    onRouteChange(tab);
+  }
+}
+
+export function initRouter(handler) {
+  if (typeof handler !== 'function') {
+    throw new TypeError('initRouter expects a handler function');
+  }
+
+  onRouteChange = handler;
+  window.addEventListener('hashchange', handleHashChange);
+  handleHashChange();
+}
+
+export function getCurrentRoute() {
+  return normaliseHash(window.location.hash);
+}
+
+export function navigateToTab(tab) {
+  if (!tab) return;
+  const desiredHash = `${HASH_PREFIX}${tab}`;
+  if (window.location.hash === desiredHash) return;
+  pendingHash = desiredHash;
+  window.location.hash = desiredHash;
+}

--- a/src/modules/tabConfig.js
+++ b/src/modules/tabConfig.js
@@ -1,0 +1,10 @@
+export const TAB_LABELS = {
+  vloot: 'Vloot',
+  activiteit: 'Activiteit',
+  users: 'Gebruikersbeheer'
+};
+
+export function getTabLabel(tab) {
+  if (!tab) return '';
+  return TAB_LABELS[tab] || tab;
+}

--- a/src/modules/tabs.js
+++ b/src/modules/tabs.js
@@ -3,7 +3,8 @@ import { state } from '../state.js';
 import { resolveEnvironment } from '../environment.js';
 import { $, $$ } from '../utils.js';
 import { renderAccountRequests } from './users.js';
-import { setMainTab } from './navigation.js';
+import { setMainTab, updateModuleCycleButton } from './navigation.js';
+import { navigateToTab, getCurrentRoute } from './router.js';
 
 export function getFleetSummaryById(fleetId) {
   if (!fleetId) return null;
@@ -26,6 +27,7 @@ export function switchMainTab(tab) {
   if (!allowedTabs.length) {
     state.activeTab = null;
     setMainTab(null);
+    updateModuleCycleButton([], null);
     return;
   }
 
@@ -33,6 +35,8 @@ export function switchMainTab(tab) {
   const targetTab = allowedTabs.includes(tab) ? tab : fallback;
   state.activeTab = targetTab;
   setMainTab(targetTab);
+  updateModuleCycleButton(allowedTabs, targetTab);
+  navigateToTab(targetTab);
 }
 
 export function applyEnvironmentForRole(role) {
@@ -69,6 +73,11 @@ export function applyEnvironmentForRole(role) {
       button.classList.toggle('opacity-40', !allowed);
     }
   });
+
+  const routeTab = getCurrentRoute();
+  if (routeTab) {
+    state.activeTab = routeTab;
+  }
 
   switchMainTab(state.activeTab);
   renderAccountRequests();

--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,117 @@
   color: var(--color-on-primary);
   background: var(--color-primary);
   border-radius: var(--radius-sm);
+  border-color: var(--color-primary) !important;
+}
+
+.main-menu {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.main-menu__item {
+  list-style: none;
+}
+
+.main-menu__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-muted);
+  font-weight: 600;
+  font-size: 0.9rem;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.main-menu__button:hover,
+.main-menu__button:focus-visible {
+  color: var(--color-text);
+  background: var(--color-highlight-bg);
+  border-color: var(--color-highlight-border);
+  outline: none;
+}
+
+.main-menu__icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.main-menu__label {
+  line-height: 1;
+}
+
+.module-cycle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.85rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.module-cycle:hover:not(:disabled) {
+  background: var(--color-highlight-bg);
+  border-color: var(--color-highlight-border);
+}
+
+.module-cycle:focus-visible {
+  outline: 3px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.module-cycle:disabled {
+  cursor: not-allowed;
+}
+
+.module-cycle--disabled {
+  opacity: 0.6;
+}
+
+.module-cycle__icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.module-cycle__label {
+  line-height: 1;
+}
+
+:root[data-theme="dark"] .main-menu__button {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+:root[data-theme="dark"] .main-menu__button:hover,
+:root[data-theme="dark"] .main-menu__button:focus-visible {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: #ffffff;
+}
+
+:root[data-theme="dark"] .module-cycle {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.14);
+  color: #ffffff;
+}
+
+:root[data-theme="dark"] .module-cycle:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.22);
+}
+
+:root[data-theme="dark"] .module-cycle--disabled {
+  opacity: 0.5;
 }
 
 .environment-pill {


### PR DESCRIPTION
## Summary
- add a labelled main menu with module icons and a top-right cycle button
- enable hash-based routing for modules and keep the location hash in sync
- centralize tab labels and refresh styling for the new navigation controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f612a36670832bbc57efd350f8cf86