### PR TITLE
Fix hours input entry and validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -491,7 +491,13 @@
       <div class="space-y-2">
         <div class="text-sm text-gray-600">Huidige urenstand: <span id="odoCurrent" class="font-medium text-gray-800">—</span></div>
         <label class="text-sm text-gray-600">Nieuwe urenstand</label>
-        <input id="odoNew" type="number" class="w-full border rounded-lg px-3 py-2" />
+        <input
+          id="odoNew"
+          type="number"
+          inputmode="numeric"
+          pattern="[0-9]*"
+          class="w-full border rounded-lg px-3 py-2"
+        />
       </div>
       <div class="mt-6 flex justify-end gap-2">
         <button data-close class="px-4 py-2 border rounded-lg">Annuleren</button>

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -340,7 +340,8 @@ export function wireEvents() {
       showToast('Geen veld voor urenstand gevonden.');
       return;
     }
-    const value = parseInt(odoInput.value, 10);
+    const rawValue = typeof odoInput.value === 'string' ? odoInput.value.trim() : '';
+    const value = rawValue === '' ? Number.NaN : Number.parseInt(rawValue, 10);
     const currentHours = typeof truck.hours === 'number' && Number.isFinite(truck.hours) ? truck.hours : null;
     if (Number.isNaN(value) || value < 0 || (currentHours !== null && value < currentHours)) {
       showToast('Nieuwe urenstand moet ≥ huidige zijn.');


### PR DESCRIPTION
## Summary
- add mobile-friendly numeric attributes to the hours input field
- trim and parse the new hours value before validating and persisting it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f616b4e2c8832bb4cbc637fc27b9dc