### PR TITLE
Refactor modals to use dialog API

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,8 +455,8 @@
 
   <!-- MODALS -->
   <!-- Servicemelding algemeen -->
-  <div id="modalTicket" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
-    <div class="bg-white w-full max-w-2xl rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
+  <dialog id="modalTicket" class="modal">
+    <div class="modal-panel bg-white w-full max-w-2xl rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Servicemelding maken</h3>
         <button data-close class="text-gray-500">✕</button>
@@ -493,11 +493,11 @@
         <button id="ticketCreate" class="px-4 py-2 bg-motrac-red text-white rounded-lg">Aanmaken</button>
       </div>
     </div>
-  </div>
+  </dialog>
 
   <!-- Urenstand doorgeven -->
-  <div id="modalOdo" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
-    <div class="bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
+  <dialog id="modalOdo" class="modal">
+    <div class="modal-panel bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Urenstand doorgeven</h3>
         <button data-close class="text-gray-500">✕</button>
@@ -518,11 +518,11 @@
         <button id="odoSave" class="px-4 py-2 bg-motrac-red text-white rounded-lg">Opslaan</button>
       </div>
     </div>
-  </div>
+  </dialog>
 
   <!-- Referentie wijzigen -->
-  <div id="modalRef" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
-    <div class="bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
+  <dialog id="modalRef" class="modal">
+    <div class="modal-panel bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Uw referentie wijzigen</h3>
         <button data-close class="text-gray-500">✕</button>
@@ -537,11 +537,11 @@
         <button id="refSave" class="px-4 py-2 bg-motrac-red text-white rounded-lg">Opslaan</button>
       </div>
     </div>
-  </div>
+  </dialog>
 
   <!-- Verwijderen uit lijst (inactief) -->
-  <div id="modalInactive" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
-    <div class="bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
+  <dialog id="modalInactive" class="modal">
+    <div class="modal-panel bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Verwijderen uit lijst</h3>
         <button data-close class="text-gray-500">✕</button>
@@ -562,11 +562,11 @@
         <button id="inactiveConfirm" class="px-4 py-2 bg-motrac-red text-white rounded-lg">Bevestigen</button>
       </div>
     </div>
-  </div>
+  </dialog>
 
   <!-- Contract inzien -->
-  <div id="modalContract" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
-    <div class="bg-white w-full max-w-xl rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
+  <dialog id="modalContract" class="modal">
+    <div class="modal-panel bg-white w-full max-w-xl rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Contract</h3>
         <button data-close class="text-gray-500">✕</button>
@@ -576,11 +576,11 @@
         <button data-close class="px-4 py-2 border rounded-lg">Sluiten</button>
       </div>
     </div>
-  </div>
+  </dialog>
 
   <!-- Gebruiker toevoegen/bewerken -->
-  <div id="modalUser" class="modal fixed inset-0 bg-black/40 items-center justify-center p-4">
-    <div class="bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
+  <dialog id="modalUser" class="modal">
+    <div class="modal-panel bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 id="userModalTitle" class="text-lg font-semibold">Gebruiker toevoegen</h3>
         <button data-close class="text-gray-500">✕</button>
@@ -617,7 +617,7 @@
         <button id="userSave" class="px-4 py-2 bg-motrac-red text-white rounded-lg">Opslaan</button>
       </div>
     </div>
-  </div>
+  </dialog>
 
   <!-- Toast -->
   <div id="toast" class="fixed bottom-4 left-1/2 -translate-x-1/2 hidden bg-gray-900 text-white px-4 py-2 rounded-lg shadow-soft"></div>

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -1,6 +1,6 @@
 import { USERS, getFleetById } from '../data.js';
 import { state } from '../state.js';
-import { $, $$, fmtDate, openModal, closeModals, kv, formatHoursLabel } from '../utils.js';
+import { $, $$, fmtDate, openModal, closeModals, closeModal, kv, formatHoursLabel } from '../utils.js';
 import { showToast } from './ui/toast.js';
 import { renderFleet, updateLocationFilter, openBmwEditor } from './fleet.js';
 import { applyFiltersFromUrl, resetFilters, syncFiltersToUrl } from './filterSync.js';
@@ -310,7 +310,25 @@ export function wireEvents() {
     }
   });
 
-  document.querySelectorAll('.modal [data-close]').forEach(button => button.addEventListener('click', closeModals));
+  document.querySelectorAll('.modal [data-close]').forEach(button => {
+    button.addEventListener('click', event => {
+      event.preventDefault();
+      const modal = button.closest('.modal');
+      if (modal) {
+        closeModal(modal);
+      } else {
+        closeModals();
+      }
+    });
+  });
+
+  document.querySelectorAll('.modal').forEach(modal => {
+    modal.addEventListener('click', event => {
+      if (event.target === modal) {
+        closeModal(modal);
+      }
+    });
+  });
   document.addEventListener('keydown', event => {
     if (event.key === 'Escape') {
       closeModals();

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,15 +43,40 @@ export const formatOdoValue = formatNumericValue;
 export const formatOdoHtml = formatNumericHtml;
 export const formatOdoLabel = formatNumericLabel;
 
+const toggleModalVisibility = (modal, shouldOpen) => {
+  if (!(modal instanceof Element)) return;
+  if (modal instanceof HTMLDialogElement) {
+    if (shouldOpen) {
+      if (!modal.open) {
+        modal.showModal();
+      }
+    } else if (modal.open) {
+      modal.close();
+    }
+    return;
+  }
+
+  if (shouldOpen) {
+    modal.classList.add('show');
+  } else {
+    modal.classList.remove('show');
+  }
+};
+
 export function openModal(selector) {
   const el = $(selector);
   if (el) {
-    el.classList.add('show');
+    toggleModalVisibility(el, true);
   }
 }
 
 export function closeModals() {
-  $$('.modal').forEach(modal => modal.classList.remove('show'));
+  $$('.modal').forEach(modal => toggleModalVisibility(modal, false));
+}
+
+export function closeModal(modal) {
+  if (!modal) return;
+  toggleModalVisibility(modal, false);
 }
 
 export const kv = (label, value) => `

--- a/styles.css
+++ b/styles.css
@@ -215,14 +215,39 @@
 }
 
 .modal {
-  display: none;
-  align-items: center;
-  justify-content: center;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  max-width: none;
   z-index: 50;
+}
+
+.modal[open] {
+  display: grid;
+  align-items: center;
+  justify-items: center;
+  width: 100vw;
+  height: 100vh;
+  padding: 1rem;
 }
 
 .modal.show {
   display: flex;
+  position: fixed;
+  inset: 0;
+  padding: 1rem;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.modal::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.modal-panel {
+  pointer-events: auto;
 }
 
 .truncate-2 {


### PR DESCRIPTION
## Summary
- migrate the portal modals to native <dialog> elements and preserve their layout classes
- update modal helpers and event wiring to open/close dialogs, including click-away dismissal
- restyle modal CSS and align the dynamic BMWT editor with the dialog-based implementation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f61f21862c832ba6266ff9960d763d