### PR TITLE
Improve users search with dynamic filters

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -5,6 +5,8 @@ export const state = {
   usersPage: 1,
   usersPageSize: 10,
   usersSearchQuery: '',
+  usersLocationFilter: 'Alle locaties',
+  usersRoleFilter: 'Alle portaalrechten',
   usersSortKey: 'name',
   usersSortDirection: 'asc',
   editUserId: null,


### PR DESCRIPTION
## Summary
- make the users search box reactive while introducing location and role filters
- refresh the filter toolbar markup, including an "Alles wissen" reset button and dropdown options sourced from the dataset
- update filtering logic and state to combine the search query with the selected dropdowns

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f661bd1968832bb6222c1f978eecce