### PR TITLE
feat: add activity status timeline and conditional actions

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,18 @@ export const fmtDate = iso => {
   return Number.isNaN(date.valueOf()) ? '—' : date.toLocaleDateString('nl-NL');
 };
 
+export const fmtDateTime = iso => {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  if (Number.isNaN(date.valueOf())) {
+    return '—';
+  }
+  return date.toLocaleString('nl-NL', {
+    dateStyle: 'short',
+    timeStyle: 'short'
+  });
+};
+
 const formatNumericValue = value => {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value.toLocaleString('nl-NL');


### PR DESCRIPTION
## Summary
- normalise fleet activity data with status history entries
- add a status history timeline and conditional action buttons in the activity detail view
- capture status updates (including reopen) with history entries and contextual toast variants

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f685941f74832bb7f31db8a8d5abb5