### PR TITLE
Improve theme toggle persistence and load behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,13 @@
         const storageKey = 'theme';
         const storedTheme = localStorage.getItem(storageKey);
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (storedTheme === 'dark' || (!storedTheme && prefersDark)) {
+        const isDark = storedTheme === 'dark' || (!storedTheme && prefersDark);
+
+        if (isDark) {
           document.documentElement.setAttribute('data-theme', 'dark');
+          document.documentElement.style.colorScheme = 'dark';
+        } else {
+          document.documentElement.style.colorScheme = 'light';
         }
       } catch (error) {
         console.error('Thema kan niet vooraf worden ingesteld:', error);

--- a/src/modules/theme.js
+++ b/src/modules/theme.js
@@ -2,17 +2,26 @@ const STORAGE_KEY = 'theme';
 const DARK = 'dark';
 const LIGHT = 'light';
 
-function applyTheme(theme) {
-  const root = document.documentElement;
-  if (theme === DARK) {
-    root.setAttribute('data-theme', DARK);
-  } else {
-    root.removeAttribute('data-theme');
-  }
+function persistTheme(theme) {
   try {
     localStorage.setItem(STORAGE_KEY, theme);
   } catch (error) {
     console.error('Thema kon niet opgeslagen worden:', error);
+  }
+}
+
+function applyTheme(theme, { persist = true } = {}) {
+  const root = document.documentElement;
+  if (theme === DARK) {
+    root.setAttribute('data-theme', DARK);
+    root.style.colorScheme = 'dark';
+  } else {
+    root.removeAttribute('data-theme');
+    root.style.colorScheme = 'light';
+  }
+
+  if (persist) {
+    persistTheme(theme);
   }
   updateToggle(theme);
 }
@@ -58,7 +67,7 @@ export function initThemeToggle() {
   const defaultTheme = prefersDark.matches ? DARK : LIGHT;
   const initialTheme = storedTheme === DARK || storedTheme === LIGHT ? storedTheme : defaultTheme;
 
-  applyTheme(initialTheme);
+  applyTheme(initialTheme, { persist: storedTheme === DARK || storedTheme === LIGHT });
 
   toggle.addEventListener('click', () => {
     const nextTheme = getActiveTheme() === DARK ? LIGHT : DARK;
@@ -75,7 +84,7 @@ export function initThemeToggle() {
       }
     })();
     if (stored !== DARK && stored !== LIGHT) {
-      applyTheme(event.matches ? DARK : LIGHT);
+      applyTheme(event.matches ? DARK : LIGHT, { persist: false });
     }
   });
 }


### PR DESCRIPTION
## Summary
- ensure the stored theme is applied as soon as the page loads and update the root color scheme to avoid flashes
- refactor the theme toggle to persist user choices safely and honour system preference changes without overwriting storage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f698a7626c832ba15262f6bfc03acb