### PR TITLE
Improve modal accessibility and focus states

### DIFF
--- a/index.html
+++ b/index.html
@@ -518,7 +518,14 @@
     <div class="modal-panel bg-white w-full max-w-2xl rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Servicemelding maken</h3>
-        <button data-close class="text-gray-500">✕</button>
+        <button
+          type="button"
+          data-close
+          class="text-gray-500"
+          aria-label="Sluit venster"
+        >
+          <span aria-hidden="true">✕</span>
+        </button>
       </div>
       <div class="grid sm:grid-cols-2 gap-4">
         <div>
@@ -575,7 +582,14 @@
     <div class="modal-panel bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Urenstand doorgeven</h3>
-        <button data-close class="text-gray-500">✕</button>
+        <button
+          type="button"
+          data-close
+          class="text-gray-500"
+          aria-label="Sluit venster"
+        >
+          <span aria-hidden="true">✕</span>
+        </button>
       </div>
       <div class="space-y-2">
         <div class="text-sm text-gray-600">Huidige urenstand: <span id="odoCurrent" class="font-medium text-gray-800">—</span></div>
@@ -600,7 +614,14 @@
     <div class="modal-panel bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Uw referentie wijzigen</h3>
-        <button data-close class="text-gray-500">✕</button>
+        <button
+          type="button"
+          data-close
+          class="text-gray-500"
+          aria-label="Sluit venster"
+        >
+          <span aria-hidden="true">✕</span>
+        </button>
       </div>
       <div class="space-y-2">
         <div class="text-sm text-gray-600">Huidige referentie: <span id="refCurrent" class="font-medium text-gray-800">—</span></div>
@@ -619,7 +640,14 @@
     <div class="modal-panel bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Verwijderen uit lijst</h3>
-        <button data-close class="text-gray-500">✕</button>
+        <button
+          type="button"
+          data-close
+          class="text-gray-500"
+          aria-label="Sluit venster"
+        >
+          <span aria-hidden="true">✕</span>
+        </button>
       </div>
       <div class="space-y-3 text-sm">
         <div>
@@ -644,7 +672,14 @@
     <div class="modal-panel bg-white w-full max-w-xl rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Contract</h3>
-        <button data-close class="text-gray-500">✕</button>
+        <button
+          type="button"
+          data-close
+          class="text-gray-500"
+          aria-label="Sluit venster"
+        >
+          <span aria-hidden="true">✕</span>
+        </button>
       </div>
       <div id="contractBody" class="text-sm grid grid-cols-1 sm:grid-cols-2 gap-3"></div>
       <div class="mt-6 text-right">
@@ -658,7 +693,14 @@
     <div class="modal-panel bg-white w-full max-w-md rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-4">
         <h3 id="userModalTitle" class="text-lg font-semibold">Gebruiker toevoegen</h3>
-        <button data-close class="text-gray-500">✕</button>
+        <button
+          type="button"
+          data-close
+          class="text-gray-500"
+          aria-label="Sluit venster"
+        >
+          <span aria-hidden="true">✕</span>
+        </button>
       </div>
       <div class="space-y-3">
         <div>
@@ -699,7 +741,14 @@
     <div class="modal-panel bg-white w-full max-w-sm rounded-xl shadow-soft p-6">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-semibold">Bevestigen</h3>
-        <button data-close class="text-gray-500">✕</button>
+        <button
+          type="button"
+          data-close
+          class="text-gray-500"
+          aria-label="Sluit venster"
+        >
+          <span aria-hidden="true">✕</span>
+        </button>
       </div>
       <p class="text-sm text-gray-600">Weet je zeker dat je deze actie wilt uitvoeren?</p>
       <div class="mt-6 flex justify-end gap-2">

--- a/styles.css
+++ b/styles.css
@@ -421,6 +421,8 @@
   pointer-events: auto;
   background: var(--color-surface);
   color: var(--color-text);
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 .truncate-2 {
@@ -473,6 +475,7 @@ body {
 
 :where(
     a:not(.btn),
+    button,
     input,
     select,
     textarea,


### PR DESCRIPTION
## Summary
- add descriptive aria-labels to icon-only modal close buttons
- ensure focus-visible outlines on generic buttons and limit modal height for mobile viewports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f699d1cf2c832b809149e2a68c48d0