### PR TITLE
Add vehicle detail modal with maintenance and BMWT sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,34 +424,6 @@
         </div>
       </section>
 
-      <!-- DETAIL: TRUCK -->
-      <section id="truckDetail" class="hidden space-y-4">
-        <div class="flex flex-wrap items-center justify-between gap-3">
-          <div class="flex items-center gap-3">
-            <button id="backToFleet" class="px-3 py-2 border rounded-lg">← Terug naar overzicht</button>
-            <h2 id="detailTitle" class="text-lg font-semibold"></h2>
-          </div>
-          <div class="hidden sm:flex items-center gap-2">
-            <button class="px-3 py-2 border rounded-lg" data-action="newTicketFromDetail">Melding aanmaken</button>
-            <button class="px-3 py-2 border rounded-lg" data-action="updateOdo">Urenstand doorgeven</button>
-            <button class="px-3 py-2 border rounded-lg" data-action="editRef">Uw referentie wijzigen</button>
-          </div>
-        </div>
-        <div class="grid grid-cols-1 sm:hidden gap-2">
-          <button class="px-3 py-2 border rounded-lg text-sm" data-action="newTicketFromDetail">Melding aanmaken</button>
-          <button class="px-3 py-2 border rounded-lg text-sm" data-action="updateOdo">Urenstand doorgeven</button>
-          <button class="px-3 py-2 border rounded-lg text-sm" data-action="editRef">Uw referentie wijzigen</button>
-        </div>
-
-        <div class="bg-white rounded-xl shadow-soft p-0">
-          <div class="border-b flex text-sm font-medium">
-            <button class="px-4 py-3 tab-active" data-subtab="info">Truck informatie</button>
-            <button class="px-4 py-3" data-subtab="act">Truck activiteit</button>
-            <button class="px-4 py-3" data-subtab="ctr">Contract</button>
-          </div>
-          <div id="detailContent" class="p-4"></div>
-        </div>
-      </section>
     </main>
     <nav
       id="mobileTabBar"
@@ -513,6 +485,64 @@
   </div>
 
   <!-- MODALS -->
+  <!-- Voertuigdetails -->
+  <dialog id="vehicleDetailModal" class="modal">
+    <div class="modal-panel bg-white w-full max-w-4xl rounded-xl shadow-soft max-h-[90vh] overflow-y-auto">
+      <div class="flex items-start justify-between gap-4 border-b px-6 py-5">
+        <div class="space-y-2">
+          <div class="text-xs font-semibold uppercase tracking-wide text-gray-400">Voertuig</div>
+          <h3 id="vehicleDetailTitle" class="text-xl font-semibold text-gray-900"></h3>
+          <p id="vehicleDetailSubtitle" class="text-sm text-gray-500"></p>
+          <div id="vehicleDetailMeta" class="mt-2 flex flex-wrap gap-2"></div>
+        </div>
+        <button
+          type="button"
+          data-close
+          class="text-gray-500 hover:text-gray-700"
+          aria-label="Sluit detailvenster"
+        >
+          ✕
+        </button>
+      </div>
+      <div class="px-6 py-6 space-y-6">
+        <div class="flex flex-wrap gap-2">
+          <button class="rounded-lg border px-4 py-2 text-sm font-medium" data-action="newTicketFromDetail">
+            Melding aanmaken
+          </button>
+          <button class="rounded-lg border px-4 py-2 text-sm font-medium" data-action="markOutOfService">
+            Buiten gebruik zetten
+          </button>
+          <button class="rounded-lg border px-4 py-2 text-sm font-medium" data-action="downloadReport">
+            Rapport downloaden
+          </button>
+        </div>
+
+        <section>
+          <h4 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Overzicht</h4>
+          <div id="vehicleDetailFacts" class="mt-3 grid gap-4 text-sm sm:grid-cols-2"></div>
+        </section>
+
+        <section>
+          <div class="flex items-center justify-between gap-3">
+            <h4 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Onderhoudshistorie</h4>
+            <span id="vehicleDetailMaintenanceCount" class="text-xs text-gray-400"></span>
+          </div>
+          <div id="vehicleDetailMaintenance" class="mt-3 space-y-3"></div>
+        </section>
+
+        <section>
+          <h4 class="text-sm font-semibold uppercase tracking-wide text-gray-500">BMWT-data</h4>
+          <div id="vehicleDetailBmwt" class="mt-3 grid gap-3 text-sm sm:grid-cols-2"></div>
+        </section>
+
+        <section>
+          <h4 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Documenten</h4>
+          <div id="vehicleDetailDocuments" class="mt-3 divide-y rounded-lg border"></div>
+        </section>
+      </div>
+    </div>
+  </dialog>
+
   <!-- Servicemelding algemeen -->
   <dialog id="modalTicket" class="modal">
     <div class="modal-panel bg-white w-full max-w-2xl rounded-xl shadow-soft p-6 max-h-[90vh] overflow-y-auto">

--- a/src/data.js
+++ b/src/data.js
@@ -31,6 +31,69 @@ const DEFAULT_FLEET = [
       { id: 'M-1001', type: 'Onderhoud', desc: 'Periodieke servicebeurt', status: 'Afgerond', date: '2025-06-20' },
       { id: 'M-1010', type: 'Storing', desc: 'Mast-sensor foutcode', status: 'Open', date: '2025-10-01' }
     ],
+    maintenanceHistory: [
+      {
+        id: 'MH-2025-09',
+        type: 'BMWT-keuring',
+        status: 'Afgerond',
+        description: 'Jaarlijkse BMWT-keuring uitgevoerd zonder bijzonderheden.',
+        date: '2025-09-15',
+        technician: 'L. de Bruin',
+        hours: '1.523 uur'
+      },
+      {
+        id: 'MH-2025-06',
+        type: 'Periodiek onderhoud',
+        status: 'Afgerond',
+        description: 'Uitgebreide inspectie en smering van mast en kettingen.',
+        date: '2025-06-20',
+        technician: 'P. van Dijk',
+        hours: '1.480 uur'
+      },
+      {
+        id: 'MH-2025-10',
+        type: 'Storing',
+        status: 'In behandeling',
+        description: 'Diagnose op mast-sensor foutcode, vervolgbezoek ingepland.',
+        date: '2025-10-02',
+        technician: 'Serviceteam Noord'
+      }
+    ],
+    bmwt: {
+      status: 'Goedgekeurd',
+      expiry: '2026-03-15',
+      lastInspection: '2025-03-14',
+      inspector: 'DEKRA Inspecties',
+      remarks: 'Volgende preventieve check ingepland voor Q1 2026.',
+      certificateUrl: '#',
+      certificateName: 'BMWT-certificaat E16 2025.pdf'
+    },
+    documents: [
+      {
+        id: 'DOC-E16-001',
+        name: 'Gebruikershandleiding Linde E16.pdf',
+        type: 'Handleiding',
+        updatedAt: '2024-11-02',
+        size: '1,2 MB',
+        url: '#'
+      },
+      {
+        id: 'DOC-E16-002',
+        name: 'Onderhoudsrapport juni 2025.pdf',
+        type: 'Onderhoudsrapport',
+        updatedAt: '2025-06-21',
+        size: '860 kB',
+        url: '#'
+      },
+      {
+        id: 'DOC-E16-003',
+        name: 'BMWT-certificaat 2025.pdf',
+        type: 'Certificaat',
+        updatedAt: '2025-03-14',
+        size: '540 kB',
+        url: '#'
+      }
+    ],
     contract: {
       nummer: 'CTR-2023-ALM-001',
       start: '2023-01-01',
@@ -57,6 +120,53 @@ const DEFAULT_FLEET = [
     },
     fleetId: 'CF-DEMO',
     activity: [],
+    maintenanceHistory: [
+      {
+        id: 'MH-2025-08',
+        type: 'Veiligheidsinspectie',
+        status: 'Afgerond',
+        description: 'Veiligheidscontrole uitgevoerd, geen gebreken gevonden.',
+        date: '2025-08-05',
+        technician: 'S. Reinders',
+        hours: '3.360 uur'
+      },
+      {
+        id: 'MH-2025-05',
+        type: 'Periodiek onderhoud',
+        status: 'Afgerond',
+        description: 'Vervanging filters en controle remsysteem.',
+        date: '2025-05-18',
+        technician: 'M. Koster',
+        hours: '3.210 uur'
+      }
+    ],
+    bmwt: {
+      status: 'Goedgekeurd',
+      expiry: '2025-12-01',
+      lastInspection: '2024-12-12',
+      inspector: 'TÜV Nederland',
+      remarks: 'Let op slijtage van banden bij volgende inspectie.',
+      certificateUrl: '#',
+      certificateName: 'BMWT-certificaat H25 2024.pdf'
+    },
+    documents: [
+      {
+        id: 'DOC-H25-001',
+        name: 'Handleiding Linde H25.pdf',
+        type: 'Handleiding',
+        updatedAt: '2024-04-03',
+        size: '1,8 MB',
+        url: '#'
+      },
+      {
+        id: 'DOC-H25-002',
+        name: 'Onderhoudsoverzicht 2025.pdf',
+        type: 'Onderhoudsrapport',
+        updatedAt: '2025-05-18',
+        size: '910 kB',
+        url: '#'
+      }
+    ],
     contract: {
       nummer: 'CTR-2022-ZWD-019',
       start: '2022-05-15',
@@ -83,6 +193,68 @@ const DEFAULT_FLEET = [
     fleetId: 'CF-VANDIJK',
     activity: [
       { id: 'M-1020', type: 'Schade', desc: 'Vork beschadigd', status: 'Open', date: '2025-10-03' }
+    ],
+    maintenanceHistory: [
+      {
+        id: 'MH-2025-07',
+        type: 'Correctief onderhoud',
+        status: 'Afgerond',
+        description: 'Vervanging hydraulische slang mastcircuit.',
+        date: '2025-07-09',
+        technician: 'G. Hermans',
+        hours: '720 uur'
+      },
+      {
+        id: 'MH-2025-09',
+        type: 'BMWT-keuring',
+        status: 'Afkeur',
+        description: 'Keuring afgekeurd wegens beschadigde vork, herkeuring vereist.',
+        date: '2025-09-01',
+        technician: 'Inspectie Rotterdam'
+      },
+      {
+        id: 'MH-2025-10',
+        type: 'Schade-opvolging',
+        status: 'Open',
+        description: 'Herstel van beschadigde vork gepland, onderdelen besteld.',
+        date: '2025-10-05',
+        technician: 'Serviceteam Zuid'
+      }
+    ],
+    bmwt: {
+      status: 'Afkeur',
+      expiry: '2025-09-01',
+      lastInspection: '2025-09-01',
+      inspector: 'BMWT Inspecties Rotterdam',
+      remarks: 'Herkeuring vereist na vervanging vork.',
+      certificateUrl: '#',
+      certificateName: 'BMWT-rapport E20 2025.pdf'
+    },
+    documents: [
+      {
+        id: 'DOC-E20-001',
+        name: 'Gebruikershandleiding Linde E20.pdf',
+        type: 'Handleiding',
+        updatedAt: '2024-07-15',
+        size: '1,5 MB',
+        url: '#'
+      },
+      {
+        id: 'DOC-E20-002',
+        name: 'Schaderapport september 2025.pdf',
+        type: 'Schaderapport',
+        updatedAt: '2025-09-03',
+        size: '640 kB',
+        url: '#'
+      },
+      {
+        id: 'DOC-E20-003',
+        name: 'Onderhoudsplan 2025-2026.pdf',
+        type: 'Onderhoudsplan',
+        updatedAt: '2025-05-01',
+        size: '780 kB',
+        url: '#'
+      }
     ],
     contract: {
       nummer: 'CTR-2024-VNL-003',
@@ -207,6 +379,96 @@ function normaliseFleetActivity(activity = []) {
   });
 }
 
+function normaliseMaintenanceHistory(history = [], fallbackActivity = []) {
+  const source = Array.isArray(history) && history.length ? history : fallbackActivity;
+
+  return (Array.isArray(source) ? source : [])
+    .map((entry, index) => {
+      const id = entry?.id || entry?.code || `maintenance-${index}`;
+      const type = pickString(entry?.type, entry?.title, entry?.category, 'Onderhoud');
+      const status = pickString(entry?.status, entry?.state, 'Onbekend');
+      const description = pickString(entry?.description, entry?.desc, entry?.summary, entry?.notes, entry?.detail, '—');
+      const date = entry?.date || entry?.performedAt || entry?.performed_at || entry?.updatedAt || entry?.updated_at || entry?.completedAt || entry?.completed_at || null;
+      const technician = pickString(entry?.technician, entry?.engineer, entry?.performedBy, entry?.performed_by, entry?.owner, entry?.assignedTo, entry?.assigned_to);
+      const hours = pickString(
+        entry?.hours,
+        entry?.hoursReading,
+        entry?.hours_reading,
+        entry?.urenstand,
+        entry?.urenstand_datum ? `${entry.urenstand} (${entry.urenstand_datum})` : null,
+        entry?.meterReading,
+        entry?.meter_reading
+      );
+
+      return {
+        id,
+        type,
+        status,
+        description,
+        date,
+        technician: technician || null,
+        hours: hours || null
+      };
+    })
+    .filter(item => item.type || item.description || item.date)
+    .sort((a, b) => {
+      const aTime = new Date(a.date ?? 0).valueOf();
+      const bTime = new Date(b.date ?? 0).valueOf();
+      return Number.isNaN(bTime - aTime) ? 0 : bTime - aTime;
+    });
+}
+
+function normaliseBmwDetails(rawDetails = null, { status: fallbackStatus, expiry: fallbackExpiry } = {}) {
+  const source = rawDetails && typeof rawDetails === 'object' ? rawDetails : {};
+
+  return {
+    status: pickString(source.status, source.bmwStatus, fallbackStatus, '—'),
+    expiry: source.expiry || source.expirationDate || source.expiration_date || fallbackExpiry || null,
+    lastInspection:
+      source.lastInspection ||
+      source.last_inspection ||
+      source.lastCheck ||
+      source.last_check ||
+      source.inspectionDate ||
+      source.inspection_date ||
+      null,
+    inspector: pickString(source.inspector, source.inspectionCompany, source.inspection_company, source.partner, null),
+    remarks: pickString(source.remarks, source.notes, source.comment, null),
+    certificateUrl: source.certificateUrl || source.certificate_url || source.certificate || null,
+    certificateName: pickString(source.certificateName, source.certificate_name, source.certificateTitle, null)
+  };
+}
+
+function normaliseDocumentList(documents = []) {
+  if (!Array.isArray(documents)) {
+    return [];
+  }
+
+  return documents
+    .map((doc, index) => {
+      const name = pickString(doc?.name, doc?.title, doc?.filename, doc?.file_name);
+      if (!name) {
+        return null;
+      }
+
+      return {
+        id: doc?.id || doc?.documentId || doc?.document_id || `doc-${index}`,
+        name,
+        type: pickString(doc?.type, doc?.category, doc?.documentType, doc?.document_type, 'Document'),
+        updatedAt:
+          doc?.updatedAt ||
+          doc?.updated_at ||
+          doc?.modifiedAt ||
+          doc?.modified_at ||
+          doc?.date ||
+          null,
+        size: pickString(doc?.size, doc?.fileSize, doc?.file_size, doc?.filesize, null),
+        url: doc?.url || doc?.href || doc?.link || '#'
+      };
+    })
+    .filter(Boolean);
+}
+
 function normaliseFleetCustomer(item = {}) {
   const rawCustomer =
     item.customer ||
@@ -281,6 +543,15 @@ function normaliseFleetCustomer(item = {}) {
 function normaliseFleetItem(item = {}) {
   const fleetId = item.fleetId || item.customerFleetId || item.customer_fleet_id || null;
   const activity = normaliseFleetActivity(item.activity);
+  const maintenanceHistory = normaliseMaintenanceHistory(
+    item.maintenanceHistory || item.maintenance_history || item.history,
+    activity
+  );
+  const bmwt = normaliseBmwDetails(
+    item.bmwt || item.bmwInspection || item.bmw_inspection || item.bmwData || item.bmw_data,
+    { status: item.bmwStatus, expiry: item.bmwExpiry }
+  );
+  const documents = normaliseDocumentList(item.documents || item.files || item.attachments);
   const hoursValue =
     item.hours ??
     item.hoursReading ??
@@ -323,6 +594,9 @@ function normaliseFleetItem(item = {}) {
     odo: hoursValue,
     odoDate: hoursDateValue,
     activity,
+    maintenanceHistory,
+    bmwt,
+    documents,
     openActivityCount: activity.filter(entry => entry?.status === 'Open').length,
     contract: normaliseContract(item.contract, item.model),
     active: typeof item.active === 'boolean' ? item.active : true

--- a/src/modules/detail.js
+++ b/src/modules/detail.js
@@ -2,85 +2,228 @@ import { getFleetById } from '../data.js';
 import { state } from '../state.js';
 import {
   $,
-  $$,
   fmtDate,
-  kv,
-  formatHoursHtml,
   formatCustomerOwnership,
+  formatHoursHtml,
   renderStatusBadge,
   getToneForBmwStatus,
-  getToneForActivityStatus
+  getToneForActivityStatus,
+  openModal
 } from '../utils.js';
 import { canViewFleetAsset } from './access.js';
 
-export function openDetail(id) {
-  state.selectedTruckId = id;
-  const truck = getFleetById(id);
-  if (!truck || !canViewFleetAsset(truck)) return;
+const DETAIL_MODAL_SELECTOR = '#vehicleDetailModal';
 
-  $('#detailTitle').textContent = `${truck.id} • ${truck.ref}`;
-  setDetailTab('info');
+let modalInitialised = false;
 
-  $('#tab-vloot').classList.add('hidden');
-  $('#tab-activiteit').classList.add('hidden');
-  $('#tab-users').classList.add('hidden');
-  $('#truckDetail').classList.remove('hidden');
-}
+function ensureModalListeners() {
+  if (modalInitialised) return;
+  const modal = $(DETAIL_MODAL_SELECTOR);
+  if (!modal) return;
 
-export function setDetailTab(tab) {
-  $$('#truckDetail [data-subtab]').forEach(button => {
-    button.classList.toggle('tab-active', button.dataset.subtab === tab);
+  modal.addEventListener('close', () => {
+    if (state.selectedTruckId) {
+      state.selectedTruckId = null;
+    }
   });
 
-  const truck = getFleetById(state.selectedTruckId);
-  if (!truck || !canViewFleetAsset(truck)) return;
+  modalInitialised = true;
+}
 
-  if (tab === 'info') {
-    $('#detailContent').innerHTML = `
-      <div class="grid sm:grid-cols-2 gap-4 text-sm">
-        ${infoRow('Objectnummer', truck.id, true)}
-        ${infoRow('Referentie', truck.ref, false, 'editRefFromDetail')}
-        ${infoRow('Vloot', truck.fleetName || '—', true)}
-        ${infoRow('Voor', formatCustomerOwnership(truck.customer, truck.fleetName || '—'), true)}
-        ${infoRow('Locatie', truck.location || '—', true)}
-        ${infoRow('Modeltype', truck.modelType || '—', true)}
-        ${infoRow('Model', truck.model)}
-        ${infoRow('Urenstand (datum)', formatHoursHtml(truck.hours, truck.hoursDate), false, 'updateOdoFromDetail')}
-        ${infoRow('BMWT‑status', renderStatusBadge(truck.bmwStatus, getToneForBmwStatus(truck.bmwStatus)))}
-        ${infoRow('BMWT‑vervaldatum', fmtDate(truck.bmwExpiry))}
-      </div>`;
-  } else if (tab === 'act') {
-    const items = truck.activity;
-    $('#detailContent').innerHTML = items.length
-      ? items.map(activity => `
-        <div class="border rounded-lg p-3 mb-2">
-          <div class="text-xs text-gray-500">${fmtDate(activity.date)} • ${activity.type}</div>
-          <div class="font-medium">${activity.id}</div>
-          <div class="text-sm">${activity.desc}</div>
-          <div class="mt-2">${renderStatusBadge(activity.status, getToneForActivityStatus(activity.status))}</div>
-        </div>`).join('')
-      : '<div class="text-gray-500">Geen actieve meldingen</div>';
-  } else {
-    const contract = truck.contract;
-    $('#detailContent').innerHTML = `
-      <div class="grid sm:grid-cols-2 gap-3 text-sm">
-        ${kv('Contractnummer', contract.nummer)}
-        ${kv('Contract type', contract.type)}
-        ${kv('Model', contract.model)}
-        ${kv('Start datum', fmtDate(contract.start))}
-        ${kv('Eind datum', fmtDate(contract.eind))}
-        ${kv('Uren per jaar', contract.uren)}
-      </div>`;
+function renderHeader(truck) {
+  const titleEl = $('#vehicleDetailTitle');
+  if (titleEl) {
+    titleEl.textContent = truck.id;
+  }
+
+  const subtitleEl = $('#vehicleDetailSubtitle');
+  if (subtitleEl) {
+    subtitleEl.textContent = truck.ref || '—';
+  }
+
+  const metaEl = $('#vehicleDetailMeta');
+  if (metaEl) {
+    const metaItems = [
+      truck.modelType ? `Modeltype: ${truck.modelType}` : null,
+      truck.model ? `Model: ${truck.model}` : null,
+      truck.location ? `Locatie: ${truck.location}` : null,
+      formatCustomerOwnership(truck.customer, truck.fleetName || '—')
+    ].filter(Boolean);
+
+    metaEl.innerHTML = metaItems
+      .map(item => `
+        <span class="inline-flex items-center gap-2 rounded-full bg-gray-100 px-3 py-1 text-xs text-gray-600">
+          ${item}
+        </span>
+      `)
+      .join('');
   }
 }
 
-function infoRow(label, value, readonly = false, actionKey = null) {
-  return `
-    <div class="bg-gray-50 rounded-lg p-3">
-      <div class="text-xs text-gray-500 mb-1">${label}</div>
-      <div class="flex items-center justify-between">
+function renderFacts(truck) {
+  const factsEl = $('#vehicleDetailFacts');
+  if (!factsEl) return;
+
+  const facts = [
+    ['Vloot', truck.fleetName || '—'],
+    ['Eigenaar', formatCustomerOwnership(truck.customer, truck.fleetName || '—')],
+    ['Status', renderStatusBadge(truck.bmwStatus, getToneForBmwStatus(truck.bmwStatus))],
+    ['BMWT-vervaldatum', fmtDate(truck.bmwExpiry)],
+    ['Urenstand (datum)', formatHoursHtml(truck.hours, truck.hoursDate)],
+    ['Contractnummer', truck.contract?.nummer || '—']
+  ];
+
+  factsEl.innerHTML = facts
+    .map(([label, value]) => `
+      <div class="rounded-lg bg-gray-50 p-3">
+        <div class="text-xs text-gray-500">${label}</div>
         <div class="font-medium">${value}</div>
-        ${readonly ? '' : `<button class="text-sm underline" data-action="${actionKey || ''}">Bewerken</button>`}
       </div>
-    </div>`;
+    `)
+    .join('');
+}
+
+function renderMaintenance(truck) {
+  const container = $('#vehicleDetailMaintenance');
+  const counter = $('#vehicleDetailMaintenanceCount');
+  if (!container || !counter) return;
+
+  const history = Array.isArray(truck.maintenanceHistory) ? truck.maintenanceHistory : [];
+  counter.textContent = history.length
+    ? `${history.length} ${history.length === 1 ? 'melding' : 'meldingen'}`
+    : 'Geen meldingen';
+
+  if (!history.length) {
+    container.innerHTML = '<p class="text-sm text-gray-500">Geen onderhoudshistorie beschikbaar.</p>';
+    return;
+  }
+
+  container.innerHTML = history
+    .map(entry => `
+      <article class="rounded-lg border border-gray-200 p-4">
+        <div class="flex flex-wrap items-center justify-between gap-3 text-sm">
+          <div class="font-semibold text-gray-800">${entry.type}</div>
+          <div class="text-xs text-gray-500">${fmtDate(entry.date)}</div>
+        </div>
+        <div class="mt-2 text-sm text-gray-600">${entry.description || '—'}</div>
+        <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-gray-500">
+          ${entry.technician ? `<span>Technicus: ${entry.technician}</span>` : ''}
+          ${entry.status ? renderStatusBadge(entry.status, getToneForActivityStatus(entry.status)) : ''}
+          ${entry.hours ? `<span>Urenstand: ${entry.hours}</span>` : ''}
+        </div>
+      </article>
+    `)
+    .join('');
+}
+
+function renderBmwt(truck) {
+  const container = $('#vehicleDetailBmwt');
+  if (!container) return;
+
+  const data = truck.bmwt || {};
+  const items = [
+    ['Huidige status', renderStatusBadge(data.status || truck.bmwStatus, getToneForBmwStatus(data.status || truck.bmwStatus))],
+    ['Vervaldatum', fmtDate(data.expiry || truck.bmwExpiry)],
+    ['Laatste keuring', fmtDate(data.lastInspection)],
+    ['Inspecteur', data.inspector || 'Onbekend'],
+    ['Opmerkingen', data.remarks || 'Geen opmerkingen beschikbaar.']
+  ];
+
+  container.innerHTML = items
+    .map(([label, value]) => `
+      <div class="rounded-lg border border-gray-200 p-3">
+        <div class="text-xs text-gray-500">${label}</div>
+        <div class="mt-1 text-sm font-medium text-gray-800">${value}</div>
+      </div>
+    `)
+    .join('');
+
+  if (data.certificateUrl) {
+    container.innerHTML += `
+      <div class="rounded-lg border border-gray-200 p-3 sm:col-span-2">
+        <div class="text-xs text-gray-500">Certificaat</div>
+        <a href="${data.certificateUrl}" class="mt-1 inline-flex items-center text-sm font-medium text-motrac-red hover:underline">${
+          data.certificateName || 'BMWT certificaat'
+        }</a>
+      </div>
+    `;
+  }
+}
+
+function renderDocuments(truck) {
+  const container = $('#vehicleDetailDocuments');
+  if (!container) return;
+
+  const documents = Array.isArray(truck.documents) ? truck.documents : [];
+
+  if (!documents.length) {
+    container.innerHTML = '<div class="px-4 py-6 text-sm text-gray-500">Geen documenten gevonden voor dit voertuig.</div>';
+    return;
+  }
+
+  container.innerHTML = documents
+    .map(
+      doc => `
+        <div class="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+          <div>
+            <div class="text-sm font-medium text-gray-800">${doc.name}</div>
+            <div class="text-xs text-gray-500">
+              ${doc.type || 'Document'} • ${fmtDate(doc.updatedAt)}${doc.size ? ` • ${doc.size}` : ''}
+            </div>
+          </div>
+          <a
+            href="${doc.url || '#'}"
+            class="text-sm font-medium text-motrac-red hover:underline"
+            target="_blank"
+            rel="noreferrer"
+          >Download</a>
+        </div>
+      `
+    )
+    .join('');
+}
+
+function renderDetail(truck) {
+  renderHeader(truck);
+  renderFacts(truck);
+  renderMaintenance(truck);
+  renderBmwt(truck);
+  renderDocuments(truck);
+}
+
+export function openDetail(id) {
+  const truck = getFleetById(id);
+  if (!truck || !canViewFleetAsset(truck)) return;
+
+  state.selectedTruckId = truck.id;
+
+  ensureModalListeners();
+  renderDetail(truck);
+
+  const modal = $(DETAIL_MODAL_SELECTOR);
+  if (modal) {
+    modal.scrollTop = 0;
+    modal.dataset.truckId = truck.id;
+  }
+
+  openModal(DETAIL_MODAL_SELECTOR);
+}
+
+export function refreshDetail() {
+  const modal = $(DETAIL_MODAL_SELECTOR);
+  if (!modal || !modal.open) {
+    return;
+  }
+
+  const truckId = modal.dataset.truckId || state.selectedTruckId;
+  if (!truckId) {
+    return;
+  }
+
+  const truck = getFleetById(truckId);
+  if (!truck || !canViewFleetAsset(truck)) {
+    return;
+  }
+
+  renderDetail(truck);
 }

--- a/src/modules/navigation.js
+++ b/src/modules/navigation.js
@@ -11,7 +11,6 @@ export function setMainTab(tab) {
   $('#tab-vloot')?.classList.toggle('hidden', tab !== 'vloot');
   $('#tab-activiteit')?.classList.toggle('hidden', tab !== 'activiteit');
   $('#tab-users')?.classList.toggle('hidden', tab !== 'users');
-  $('#truckDetail')?.classList.add('hidden');
 }
 
 export function updateModuleCycleButton(allowedTabs, activeTab) {


### PR DESCRIPTION
## Summary
- add a vehicle detail modal that opens from the fleet table with maintenance history, BMWT data, and document sections
- enrich the demo fleet dataset with maintenance entries, BMWT metadata, and related document records
- update event handlers to drive the new modal actions, refresh detail data after edits, and support marking vehicles out of service

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f69b1cb6e8832b9bfafa17f9ff9637