### PR TITLE
Add export options for fleet and user lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,6 +286,23 @@
           </div>
         </div>
 
+        <div class="flex flex-wrap justify-end gap-2">
+          <button
+            id="fleetExportCsv"
+            type="button"
+            class="px-3 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50"
+          >
+            Exporteer naar CSV
+          </button>
+          <button
+            id="fleetExportPdf"
+            type="button"
+            class="px-3 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50"
+          >
+            Exporteer naar PDF
+          </button>
+        </div>
+
         <!-- Table -->
         <div class="bg-white rounded-xl shadow-soft p-2 overflow-auto responsive-table">
           <table class="min-w-full text-sm">
@@ -333,10 +350,26 @@
 
       <!-- USERS -->
       <section id="tab-users" class="hidden space-y-4">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-semibold">Portalgebruikers</h2>
-          <div class="flex items-center gap-2">
-            <label class="text-sm">Records per page</label>
+        <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div class="flex flex-wrap items-center gap-2">
+            <h2 class="text-lg font-semibold">Portalgebruikers</h2>
+            <button
+              id="usersExportCsv"
+              type="button"
+              class="px-3 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50"
+            >
+              Exporteer naar CSV
+            </button>
+            <button
+              id="usersExportPdf"
+              type="button"
+              class="px-3 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50"
+            >
+              Exporteer naar PDF
+            </button>
+          </div>
+          <div class="flex flex-wrap items-center gap-2 md:justify-end">
+            <label class="text-sm" for="usersPageSize">Records per page</label>
             <select id="usersPageSize" class="border rounded-lg px-2 py-1">
               <option>5</option>
               <option selected>10</option>

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -2,7 +2,7 @@ import { USERS, getFleetById } from '../data.js';
 import { state } from '../state.js';
 import { $, $$, fmtDate, openModal, closeModals, closeModal, kv, formatHoursLabel } from '../utils.js';
 import { showToast } from './ui/toast.js';
-import { renderFleet, updateLocationFilter, openBmwEditor } from './fleet.js';
+import { renderFleet, updateLocationFilter, openBmwEditor, exportFleet } from './fleet.js';
 import { applyFiltersFromUrl, resetFilters, syncFiltersToUrl } from './filterSync.js';
 import {
   renderActivity,
@@ -14,7 +14,7 @@ import {
   resetTicketAttachments,
   refreshMeldingen
 } from './activity.js';
-import { renderUsers, saveUser } from './users.js';
+import { renderUsers, saveUser, exportUsers } from './users.js';
 import { openDetail, refreshDetail } from './detail.js';
 import { canViewFleetAsset } from './access.js';
 import { switchMainTab } from './tabs.js';
@@ -265,6 +265,14 @@ export function wireEvents() {
 
   $('#resetFiltersBtn')?.addEventListener('click', () => {
     handleLocationChange('Alle locaties');
+  });
+
+  $('#fleetExportCsv')?.addEventListener('click', () => {
+    exportFleet('csv');
+  });
+
+  $('#fleetExportPdf')?.addEventListener('click', () => {
+    exportFleet('pdf');
   });
 
   document.addEventListener('keydown', event => {
@@ -688,6 +696,14 @@ export function wireEvents() {
   $('#usersPageSize')?.addEventListener('change', () => {
     state.usersPage = 1;
     renderUsers();
+  });
+
+  $('#usersExportCsv')?.addEventListener('click', () => {
+    exportUsers('csv');
+  });
+
+  $('#usersExportPdf')?.addEventListener('click', () => {
+    exportUsers('pdf');
   });
 
   $('#moduleCycleBtn')?.addEventListener('click', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -172,3 +172,187 @@ export function formatCustomerOwnership(customer, fallback = '—') {
 
   return '—';
 }
+
+const CSV_DELIMITER = ';';
+const CSV_BOM = '\ufeff';
+
+const toCsvValue = value => {
+  const stringValue = value == null ? '' : String(value);
+  const escaped = stringValue.replace(/"/g, '""');
+  if (escaped.includes(CSV_DELIMITER) || /["\n\r]/.test(escaped)) {
+    return `"${escaped}"`;
+  }
+  return escaped;
+};
+
+export function createCsvContent(headers, rows, delimiter = CSV_DELIMITER) {
+  const effectiveDelimiter = typeof delimiter === 'string' && delimiter.length ? delimiter : CSV_DELIMITER;
+  const headerLine = headers.map(header => toCsvValue(header)).join(effectiveDelimiter);
+  const dataLines = rows.map(row => row.map(cell => toCsvValue(cell)).join(effectiveDelimiter));
+  return [CSV_BOM + headerLine, ...dataLines].join('\r\n');
+}
+
+export function downloadBlob(blob, filename) {
+  if (!(blob instanceof Blob)) return;
+  const safeName = typeof filename === 'string' && filename.trim() ? filename.trim() : 'export.dat';
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = safeName;
+  link.rel = 'noopener';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  requestAnimationFrame(() => URL.revokeObjectURL(url));
+}
+
+const sanitizeForPdf = value => {
+  if (value == null) return '';
+  let text = String(value);
+  if (typeof text.normalize === 'function') {
+    text = text.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
+  }
+  text = text.replace(/[^\x20-\x7E]/g, '?');
+  return text.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+};
+
+const normalizeExportValue = value => (value == null ? '' : String(value).trim());
+
+const buildRowSegments = (value, width) => {
+  const sanitized = sanitizeForPdf(value);
+  const segments = [];
+  if (!sanitized.length) {
+    segments.push('');
+    return segments;
+  }
+  for (let index = 0; index < sanitized.length; index += width) {
+    segments.push(sanitized.slice(index, index + width));
+  }
+  return segments;
+};
+
+const buildTableLines = (headers, rows) => {
+  const normalisedHeaders = headers.map(header => normalizeExportValue(header) || ' ');
+  const normalisedRows = rows.map(row => headers.map((_, index) => normalizeExportValue(row[index])));
+  const sanitizedLength = value => sanitizeForPdf(value || '').length;
+  const columnWidths = normalisedHeaders.map((header, index) => {
+    const headerLength = sanitizedLength(header);
+    const maxCell = normalisedRows.reduce((max, row) => Math.max(max, sanitizedLength(row[index])), headerLength);
+    return Math.max(4, Math.min(40, maxCell || headerLength || 4));
+  });
+
+  const padCell = (value, index) => {
+    const width = columnWidths[index];
+    return value.padEnd(width, ' ');
+  };
+
+  const headerLines = [];
+  const headerSegments = normalisedHeaders.map((header, index) => buildRowSegments(header, columnWidths[index]));
+  const headerLineCount = Math.max(...headerSegments.map(segments => segments.length));
+  for (let lineIndex = 0; lineIndex < headerLineCount; lineIndex += 1) {
+    const line = headerSegments
+      .map((segments, colIndex) => padCell(segments[lineIndex] ?? '', colIndex))
+      .join('   ');
+    headerLines.push(line);
+  }
+
+  const separator = columnWidths
+    .map(width => '-'.repeat(Math.min(width, 40)).padEnd(width, '-'))
+    .join('   ');
+
+  const bodyLines = [];
+  normalisedRows.forEach(row => {
+    const segments = row.map((cell, index) => buildRowSegments(cell, columnWidths[index]));
+    const segmentCount = Math.max(...segments.map(items => items.length));
+    for (let lineIndex = 0; lineIndex < segmentCount; lineIndex += 1) {
+      const line = segments
+        .map((items, colIndex) => padCell(items[lineIndex] ?? '', colIndex))
+        .join('   ');
+      bodyLines.push(line);
+    }
+  });
+
+  return { headerLines, separator, bodyLines };
+};
+
+const concatUint8Arrays = arrays => {
+  const totalLength = arrays.reduce((total, array) => total + array.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  arrays.forEach(array => {
+    result.set(array, offset);
+    offset += array.length;
+  });
+  return result;
+};
+
+export function createTablePdfBlob({ title, headers, rows }) {
+  const encoder = new TextEncoder();
+  const safeTitle = sanitizeForPdf(normalizeExportValue(title) || 'Export');
+  const { headerLines, separator, bodyLines } = buildTableLines(headers, rows);
+  const lines = [safeTitle, '', ...headerLines, separator, ...bodyLines];
+
+  const marginLeft = 40;
+  const startY = 800;
+  const contentParts = ['BT', `1 0 0 1 ${marginLeft} ${startY} Tm`, '12 Tf', '16 TL'];
+  lines.forEach((line, index) => {
+    if (index === 0) {
+      contentParts.push(`(${line}) Tj`);
+    } else {
+      contentParts.push('T*');
+      contentParts.push(`(${line}) Tj`);
+    }
+  });
+  contentParts.push('ET');
+
+  const contentStream = contentParts.join('\n');
+  const headerBuffer = encoder.encode('%PDF-1.4\n');
+  const contentBuffer = encoder.encode(contentStream);
+  const objects = [
+    '1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n',
+    '2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n',
+    '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n',
+    `4 0 obj\n<< /Length ${contentBuffer.length} >>\nstream\n${contentStream}\nendstream\nendobj\n`,
+    '5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Courier >>\nendobj\n'
+  ];
+  const objectBuffers = objects.map(object => encoder.encode(object));
+
+  const offsets = [0];
+  let runningOffset = headerBuffer.length;
+  objectBuffers.forEach(buffer => {
+    offsets.push(runningOffset);
+    runningOffset += buffer.length;
+  });
+
+  const xrefOffset = runningOffset;
+  let xrefContent = `xref\n0 ${objects.length + 1}\n`;
+  xrefContent += '0000000000 65535 f \n';
+  for (let index = 1; index <= objects.length; index += 1) {
+    xrefContent += `${offsets[index].toString().padStart(10, '0')} 00000 n \n`;
+  }
+  const xrefBuffer = encoder.encode(xrefContent);
+
+  const trailerContent = `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`;
+  const trailerBuffer = encoder.encode(trailerContent);
+
+  const pdfBytes = concatUint8Arrays([headerBuffer, ...objectBuffers, xrefBuffer, trailerBuffer]);
+  return new Blob([pdfBytes], { type: 'application/pdf' });
+}
+
+const normaliseFilenamePart = value => {
+  if (typeof value !== 'string') return 'export';
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return 'export';
+  return trimmed.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'export';
+};
+
+export function buildExportFilename(prefix, extension) {
+  const base = normaliseFilenamePart(prefix);
+  const ext = typeof extension === 'string' ? extension.trim().replace(/^\./, '') : '';
+  const now = new Date();
+  const stamp = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}_${String(
+    now.getHours()
+  ).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}`;
+  const suffix = ext ? `${base}-${stamp}.${ext}` : `${base}-${stamp}`;
+  return suffix;
+}


### PR DESCRIPTION
## Summary
- add CSV and PDF export buttons to the fleet and user overviews
- generate filtered and sorted exports with shared CSV/PDF utilities
- trigger downloads via Blob URLs and confirm completion with a toast

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f69dca6a90832bbc0bf66cee861a78