### PR TITLE
Improve dark theme hover feedback in fleet overview

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -821,6 +821,19 @@ h4 {
   box-shadow: var(--shadow-md) !important;
 }
 
+:root[data-theme="dark"] #tab-vloot .responsive-table tbody tr {
+  transition: background-color 0.2s ease;
+}
+
+:root[data-theme="dark"] #tab-vloot .responsive-table tbody tr:hover,
+:root[data-theme="dark"] #tab-vloot .responsive-table tbody tr:focus-within {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+:root[data-theme="dark"] #tab-vloot .responsive-table tbody tr .kebab-menu button:hover {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
 @media (max-width: 600px) {
   .theme-toggle {
     right: 16px;


### PR DESCRIPTION
## Summary
- restore hover and focus background feedback for fleet overview rows in dark mode
- ensure fleet action menu items keep a visible hover state with the dark theme overrides

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f6b256e7b0832bb1d5250d248a0bce