### PR TITLE
Prevent banner layout shift when switching pages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -26,6 +26,15 @@
   color-scheme: light;
 }
 
+html {
+  height: 100%;
+}
+
+body {
+  min-height: 100%;
+  overflow-y: scroll;
+}
+
 /* --- Application specific helpers ------------------------------------- */
 
 .tab-active {


### PR DESCRIPTION
## Summary
- keep the vertical scrollbar visible at all times to avoid the header shifting between pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f74c0cb9bc832b9a465b2e95fff166