### PR TITLE
Fix dark theme hover background color

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -787,6 +787,13 @@ h4 {
   background-color: rgba(255, 255, 255, 0.08) !important;
 }
 
+:root[data-theme="dark"] .hover\:bg-gray-50:hover,
+:root[data-theme="dark"] .focus-within\:bg-gray-50:focus-within,
+:root[data-theme="dark"] .focus\:bg-gray-50:focus {
+  background-color: rgba(255, 255, 255, 0.12) !important;
+  color: var(--color-text) !important;
+}
+
 @media (max-width: 600px) {
   .theme-toggle {
     right: 16px;


### PR DESCRIPTION
## Summary
- adjust hover and focus background colors for gray utility classes in dark theme to avoid light contrast issues

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f75126242c832bb36aefdabb52a7dc